### PR TITLE
Prep kit: solana-x402-bridge skill (for Devin to build)

### DIFF
--- a/prep-kits/solana-x402-bridge/.env.example
+++ b/prep-kits/solana-x402-bridge/.env.example
@@ -27,3 +27,9 @@ MAX_BRIDGE_ETA_SECONDS=300
 
 # Cross-chain swap (any-token, e.g. SOL->ETH) slippage tolerance
 DEFAULT_SLIPPAGE_BPS=50
+
+# RPC health switcher (cross-chain failover)
+POLYGON_FALLBACK_RPCS=            # comma-separated EVM fallbacks
+ETHEREUM_FALLBACK_RPCS=
+EVM_MAX_BLOCK_LAG=10
+RPC_PROBE_TIMEOUT_MS=2500

--- a/prep-kits/solana-x402-bridge/.env.example
+++ b/prep-kits/solana-x402-bridge/.env.example
@@ -24,3 +24,6 @@ POLYMARKET_API_URL=https://clob.polymarket.com
 # Onramper fiat aggregator (fiat-onramp module)
 ONRAMPER_API_KEY=
 MAX_BRIDGE_ETA_SECONDS=300
+
+# Cross-chain swap (any-token, e.g. SOL->ETH) slippage tolerance
+DEFAULT_SLIPPAGE_BPS=50

--- a/prep-kits/solana-x402-bridge/.env.example
+++ b/prep-kits/solana-x402-bridge/.env.example
@@ -20,3 +20,7 @@ RPC_MAX_SLOT_LAG=150
 
 # Polymarket (demo layer)
 POLYMARKET_API_URL=https://clob.polymarket.com
+
+# Onramper fiat aggregator (fiat-onramp module)
+ONRAMPER_API_KEY=
+MAX_BRIDGE_ETA_SECONDS=300

--- a/prep-kits/solana-x402-bridge/.env.example
+++ b/prep-kits/solana-x402-bridge/.env.example
@@ -1,0 +1,22 @@
+# Solana side
+SOLANA_RPC_URL=https://mainnet.helius-rpc.com/?api-key=YOUR_KEY
+SOLANA_WALLET_PRIVATE_KEY=        # base58; demo wallet only
+SOLANA_FALLBACK_RPCS=             # comma-separated, for rpc-health failover
+
+# EVM side
+POLYGON_RPC_URL=
+EVM_WALLET_PRIVATE_KEY=           # demo wallet only
+
+# Relayer (generalized from gnosis-card-x402)
+X402_RELAYER_URL=https://bridge.clawdrop.live
+INTEGRATOR_FEE_BPS=15             # 0.15% — configurable; default HFSP
+INTEGRATOR_FEE_ACCOUNT=           # defaults to HFSP wallet if empty
+
+# Safety guardrails
+MAX_BRIDGE_USDC_PER_TX=100
+MAX_BRIDGE_USDC_PER_DAY=500
+DEST_ALLOWLIST=polygon,gnosis,base
+RPC_MAX_SLOT_LAG=150
+
+# Polymarket (demo layer)
+POLYMARKET_API_URL=https://clob.polymarket.com

--- a/prep-kits/solana-x402-bridge/BUILD-BRIEF.md
+++ b/prep-kits/solana-x402-bridge/BUILD-BRIEF.md
@@ -1,0 +1,147 @@
+# BUILD BRIEF — `solana-x402-bridge` Agent Skill + Relayer
+
+**Audience:** Devin (build agent). This is your complete spec. Build from it directly.
+**Goal:** Ship a Solana AI Kit skill package that lets a Solana agent bridge USDC to any EVM chain via the HFSP x402 relayer, then act on it — with a Polymarket betting flow as the flagship demo.
+**Deadline context:** Bounty submission window is tight (~24h sprint). Prioritize the MVP path. Ship working > complete.
+
+---
+
+## 0. Why this wins (do not lose this framing)
+
+- The Superteam Brasil bounty (`solanabr/skill-bounty`, `solanabr/solana-ai-kit`) has ~158 submissions. Almost all are tx-debuggers, security audits, token launchers — heavily saturated.
+- **There is NO real cross-chain asset-bridge skill in the entire field.** The one PR named `solana-bridge-skill` (#61) is a mislabeled frontend-codegen skill. Foundation's `eth-to-sol` is code porting, not asset bridging.
+- **There is NO Polymarket / betting-execution skill anywhere.** The only prediction-market PR (#44) is on-chain settlement safety, not reading/placing bets.
+- We already built the hard part: `packages/gnosis-card-x402` bridges Solana/Base USDC → Gnosis Chain via x402. This skill **generalizes that to any EVM** and adds a betting demo.
+
+**Winning combination = genuine white space + already-built core + cross-chain "wow" demo.**
+
+**Bounty-fit guardrail:** This is a *Solana* AI Kit bounty. The Solana side is ALWAYS the front door — a Solana agent / Solana wallet initiates everything. Polymarket (Polygon) is reached *through* the bridge. Lead every README/demo with the Solana origin so judges never question relevance.
+
+---
+
+## 1. What already exists (reuse, do not rebuild)
+
+| Asset | Path | What it gives you |
+|---|---|---|
+| x402 bridge service | `packages/gnosis-card-x402` | `/quote` + execute endpoints, x402 payment header handling, Solana+Base USDC intake, ~90s settlement to Gnosis |
+| Bridge config | `packages/gnosis-card-x402/src/config.ts` | chain configs, token addresses, payment wallets |
+| Solana swap module | `packages/wdk-solana-swap` | Jupiter swap pattern, slippage/fee guard, agent-friendly (no UI) |
+| EVM contracts | `packages/gnosis-card-contracts` | Solidity routing scaffold (Hardhat + OZ) |
+
+**Your job:** wrap + generalize these behind a clean skill interface, add multi-EVM target registry, add the integrator-fee layer, add the Polymarket demo layer.
+
+---
+
+## 2. Architecture
+
+```
+Solana Agent (Claude Code + this skill)
+        │  reads SKILL.md, calls scripts/
+        ▼
+ scripts/*.ts  (thin open-source client — NO secrets, NO hardcoded fee skim)
+        │  HTTPS + x402 payment
+        ▼
+ HFSP x402 Relayer  (hosted; generalized from gnosis-card-x402)
+   ├─ /quote        → route + fees + ETA (fee disclosed here)
+   ├─ /execute      → performs bridge, returns dest tx
+   ├─ /targets      → supported EVM chains + tokens
+   └─ /status/:id   → settlement status
+        │
+        ▼
+ Destination EVM chain (Polygon for Polymarket, Gnosis, Base, Arbitrum, ...)
+        │
+        ▼
+ Polymarket (demo layer) — read markets, place bet, redeem
+```
+
+**Fee lives in the RELAYER, not the skill.** The skill is MIT/open — a hardcoded skim is strippable in 3 lines and looks bad to judges. The relayer's x402 price IS the fee. See §5.
+
+---
+
+## 3. Modules to build
+
+### Core (MVP — must ship)
+1. **`bridge-quote`** — given (amountUSDC, destChain, destToken), return route, **disclosed fee breakdown**, network fees, amountOut, ETA. Pure read. → `scripts/bridge-quote.ts`
+2. **`bridge-execute`** — pay via x402, trigger relayer, return source+dest tx + status handle. → `scripts/bridge-execute.ts`
+3. **`bridge-safety`** — preflight gate: destination allowlist, per-tx + daily spend caps, slippage/min-amountOut check, and **freshness guard** (reject if source RPC slot-lag > threshold — never act on stale balance). Confirmation monitor on both chains. → `scripts/bridge-safety.ts` + `scripts/rpc-health.ts`
+4. **`evm-targets`** — registry of supported EVM chains + token addresses + relayer endpoints. → `scripts/evm-targets.ts`
+
+### Demo layer (flagship — ship if MVP done; this is the "wow")
+5. **`polymarket-read`** — list/search markets, current odds, user positions. → `scripts/polymarket.ts`
+6. **`polymarket-bet`** — place a bet (USDC.e on Polygon), redeem winnings. Reuse partial code we already have. → `scripts/polymarket.ts`
+
+Each module = a folder with `SKILL.md` (frontmatter `name` + `description`) + reference to its script.
+
+---
+
+## 4. Requirements / prerequisites
+
+- Node 20+, TypeScript, tsx.
+- `@solana/web3.js` (Solana side), `viem` or `ethers` (EVM side).
+- Helius (or equivalent) Solana RPC — env var, never committed.
+- One EVM RPC per supported chain (Polygon mandatory for Polymarket).
+- Relayer base URL as env var (`X402_RELAYER_URL`), default to HFSP hosted.
+- Polymarket: CLOB API + USDC.e on Polygon. Use Polymarket's CLOB client.
+- Testnet/small-amount mode for the demo (money movement = judge scrutiny; demo safely).
+
+---
+
+## 5. Fee model (the monetization — keep it honest)
+
+- **Where:** charged by the relayer via x402. The bridge call's x402 price is the fee. Forking the open skill does NOT remove it.
+- **Rate:** small + dual-structured so it's attractive at all sizes:
+  - tiny flat floor (a few cents) so micro-bridges are worth relaying, **plus**
+  - **5–25 bps** (0.05–0.25%) on amount. Stay ≤25 bps — reads as "cheap" vs typical 0–0.3%.
+- **Configurable:** expose `integratorFeeBps` + `feeAccount` (Jupiter referral pattern), defaulting to HFSP wallet. Partners/forkers can set their own → invites integration instead of fee-stripping.
+- **Transparency is mandatory:** `bridge-quote` MUST return the full fee breakdown (see example in `skills/bridge-quote/SKILL.md`). Hidden fees = bad UX + bad optics.
+- **Optics:** the skill's pitch is the CAPABILITY (Solana agents reach EVM markets). The fee is a quiet, disclosed line — never the story.
+
+---
+
+## 6. Acceptance criteria (definition of done)
+
+MVP:
+- [ ] `bridge-quote.ts <amount> <chain> <token>` returns a correct quote with disclosed fee breakdown.
+- [ ] `bridge-execute.ts` completes a small real USDC bridge Solana → Polygon and returns both tx hashes.
+- [ ] `bridge-safety` blocks: a destination not on the allowlist, an over-cap amount, and a stale-RPC read.
+- [ ] `evm-targets` lists ≥3 EVM chains incl. Polygon.
+- [ ] Every module has a `SKILL.md` with valid frontmatter; top-level `SKILL.md` routes between them.
+- [ ] README runs the 60s demo with only env vars (no code edits).
+- [ ] MIT LICENSE present.
+
+Flagship:
+- [ ] `polymarket-read` lists live markets + odds.
+- [ ] `polymarket-bet` places a small bet on Polygon and can redeem.
+- [ ] End-to-end demo: Solana wallet → bridge → bet on a real Polymarket market, all from the agent.
+
+---
+
+## 7. Demo script (60 seconds — see examples/demo/cross-chain-bet.md)
+
+1. Agent: "Bet 5 USDC that <event> resolves YES on Polymarket."
+2. `bridge-quote` → shows route Solana→Polygon, fee `0.0075 USDC (15 bps)`, ETA 45s.
+3. `bridge-safety` preflight passes (within caps, RPC fresh, dest allowlisted).
+4. `bridge-execute` → USDC lands on Polygon (~45–90s). Show both explorer links.
+5. `polymarket-bet` → bet placed. Show position.
+6. Narrate: "Initiated from a Solana wallet. One skill. Cross-chain."
+
+---
+
+## 8. Submission
+
+- Package the skill (this folder's `skills/` + `scripts/` + `README` + `LICENSE`) as a standalone repo `solana-x402-bridge-skill`.
+- Submit PR to `solanabr/skill-bounty` (and optionally as a submodule to `solanabr/solana-ai-kit`).
+- PR description: 3 lines — (1) the gap it fills (no real bridge skill exists), (2) the 60s demo command, (3) "Solana front door" relevance note.
+
+---
+
+## 9. Build order for the 24h sprint
+
+1. `evm-targets` + `bridge-quote` (read-only, fast, proves the interface). 
+2. `bridge-safety` + `rpc-health` (guardrails — judges reward these on money movement).
+3. `bridge-execute` (wire to generalized relayer; reuse gnosis-card-x402).
+4. Relayer: generalize `gnosis-card-x402` to multi-EVM + add fee param.
+5. `polymarket-read` then `polymarket-bet` (flagship demo).
+6. README + demo recording.
+
+Stop after step 3 = a valid, winning bridge submission. Steps 4–6 make it spectacular.

--- a/prep-kits/solana-x402-bridge/BUILD-BRIEF.md
+++ b/prep-kits/solana-x402-bridge/BUILD-BRIEF.md
@@ -145,3 +145,70 @@ Flagship:
 6. README + demo recording.
 
 Stop after step 3 = a valid, winning bridge submission. Steps 4–6 make it spectacular.
+
+---
+
+## 10. UPDATE — Bridge AGGREGATION + Onramper fiat layer
+
+This reframes the product from "a bridge" to **"the Jupiter of cross-chain for agents"**: aggregate multiple bridge providers, quote them all, return the best net rate. Plus an optional **Onramper** fiat layer so an agent can be funded by card/bank and cash out winnings.
+
+### 10.1 Two aggregation layers
+
+```
+ FIAT (card / bank, 130+ methods)
+        │  Onramper (aggregates 20+ onramp providers, ranked)
+        ▼
+ USDC on Solana  ─┐
+                  │  BRIDGE AGGREGATOR (this skill) — quote N providers, pick best net-of-fee
+                  ▼
+ USDC on any EVM chain  →  execute (e.g. Polymarket bet)
+        │
+        ▼ (optional cash-out)
+ Onramper OFFRAMP → fiat
+```
+
+### 10.2 Bridge route aggregator (CORE — the new headline)
+
+New module **`bridge-aggregator`**: query every supported provider in parallel, normalize quotes, rank by **amountOut net of all fees + gas**, subject to ETA + reliability, then add our transparent integrator fee on top. `bridge-quote` now returns the **best** route plus the full per-provider comparison (so the agent — and judges — see we actually shopped the rate).
+
+**Providers to integrate (Solana → EVM capable):**
+| Provider | Why | Notes |
+|---|---|---|
+| **Circle CCTP** | Native 1:1 USDC burn/mint, lowest cost, no slippage | Best for USDC specifically; supports Solana + major EVM. Make it the default benchmark. |
+| **Mayan Finance** | Solana-native cross-chain (Wormhole + Swift/MCTP) | Strong Solana↔EVM coverage |
+| **deBridge (DLN)** | Fast intent-based Solana↔EVM | |
+| **Wormhole / Portal** | Canonical token bridge | fallback / wrapped |
+| **Allbridge** | Stablecoin Solana↔EVM | |
+| **LI.FI** | EVM(+Solana) bridge+DEX aggregator | can act as a meta-provider; useful as a sanity benchmark |
+| **HFSP x402 relayer** | our own route (gnosis-card-x402 generalized) | always quote it too; it carries our fee natively |
+
+**Adapter pattern:** each provider implements a common `BridgeProvider` interface (`quote()`, `execute()`, `status()`). The aggregator iterates adapters. Adding a provider = adding one adapter file. See `scripts/providers.ts`.
+
+**Ranking:** maximize `amountOutUSDC` after provider fee + gas + our integrator fee; filter out providers above `maxEtaSeconds` or below a reliability floor; tie-break on speed. Always return the ranked list, not just the winner.
+
+### 10.3 Onramper fiat layer (BONUS — funnel extension)
+
+New module **`fiat-onramp`** wrapping Onramper (API key + signed requests; widget or pure API):
+- **Onramp:** fiat → USDC delivered on Solana (or directly on the destination EVM chain). Onramper already ranks 20+ providers — we surface its best quote alongside our bridge quote so the agent can choose "fund + bridge" or "fund directly on destination."
+- **Offramp:** USDC → fiat for cashing out winnings.
+- **Quote-first, always disclosed.** Onramper provider fees shown transparently, same rule as bridge fees.
+
+Onramper supports onramp, offramp, and crypto swaps via a unified API with provider ranking/recommendations. Treat it as the fiat aggregator analog to our bridge aggregator.
+
+### 10.4 Updated module list
+Core: `bridge-aggregator` (NEW headline), `bridge-quote` (now returns aggregated best + comparison), `bridge-execute` (routes to the chosen provider's adapter), `bridge-safety`, `evm-targets` (now also provider registry).
+Funnel: `fiat-onramp` (NEW — Onramper).
+Demo: `polymarket-read`, `polymarket-bet`.
+
+### 10.5 Updated build order (24h)
+1. `evm-targets` + provider registry/adapters skeleton (`scripts/providers.ts`).
+2. **CCTP adapter + Mayan adapter + our x402 route** → `bridge-aggregator` ranking → `bridge-quote` returns best + comparison. (3 providers is enough to prove aggregation.)
+3. `bridge-safety` + `rpc-health`.
+4. `bridge-execute` routing to chosen adapter.
+5. `fiat-onramp` (Onramper) — onramp quote first, offramp if time.
+6. `polymarket-read` → `polymarket-bet` (flagship demo).
+
+**MVP to win = steps 1–4 with ≥3 providers aggregated.** That alone is novel (no aggregator bridge skill exists). Onramper + Polymarket make it a complete fiat→bet funnel.
+
+### 10.6 Positioning update
+"The Jupiter of cross-chain for Solana agents — aggregate every bridge, quote the best rate, optionally fund with fiat, and execute on EVM." Lead with aggregation; it's the differentiator and the judge-legible value (you can *prove* best-rate selection on screen).

--- a/prep-kits/solana-x402-bridge/BUILD-BRIEF.md
+++ b/prep-kits/solana-x402-bridge/BUILD-BRIEF.md
@@ -212,3 +212,41 @@ Demo: `polymarket-read`, `polymarket-bet`.
 
 ### 10.6 Positioning update
 "The Jupiter of cross-chain for Solana agents — aggregate every bridge, quote the best rate, optionally fund with fiat, and execute on EVM." Lead with aggregation; it's the differentiator and the judge-legible value (you can *prove* best-rate selection on screen).
+
+---
+
+## 11. UPDATE — Any-token transfers (bridge AND cross-chain swap)
+
+The skill now handles two transfer kinds:
+- **bridge** — same asset, e.g. USDC→USDC. 1:1, no slippage.
+- **swap** — different destination token, e.g. **SOL→ETH**. Has slippage + price impact (swap legs on both chains).
+
+### 11.1 Provider capability matrix
+| Provider | USDC→USDC bridge | Any-token swap (SOL→ETH) |
+|---|---|---|
+| CCTP | ✅ native 1:1 | ❌ USDC only |
+| Mayan | ✅ | ✅ core feature (any→any) |
+| deBridge DLN | ✅ | ✅ (intent: sell SOL → receive ETH) |
+| Wormhole | ✅ (CCTP/token bridge) | ⚠️ needs swap legs — treated as same-asset only here |
+| Allbridge | ✅ stables | ❌ stable pools only |
+
+`supportsPair(srcToken, chain, destToken)` on each adapter decides eligibility. For SOL→ETH the aggregator's eligible set automatically becomes **Mayan + deBridge**.
+
+### 11.2 What changes in code
+- Interface is now `(srcToken, amountIn, destChain, destToken)` everywhere (see `types.ts`, `providers.ts`).
+- `BridgeQuote` adds `kind`, `srcToken`, `destToken`, `priceImpactBps`, `slippageBps`, `minAmountOut`.
+- Ranking still = best net `amountOut` (in destToken).
+
+### 11.3 Safety (CRITICAL for swaps)
+Volatile pairs make slippage a loss vector. `bridge-safety` MUST:
+- Enforce `slippageBps` tolerance and reject if quoted `amountOut < minAmountOut`.
+- Re-quote immediately before execute (prices move); abort if drift > tolerance.
+- Keep the stale-RPC freshness guard (never act on lagging price/balance).
+USDC bridges set `priceImpactBps = 0` and skip slippage logic.
+
+### 11.4 Demo vs capability (do not blur)
+- **Primary demo stays USDC → Polymarket** — stable, deterministic, no slippage surprises in a 24h window.
+- **SOL→ETH is a showcased second capability** ("the aggregator also does cross-chain swaps"), demoed with a tiny amount on testnet/small size. Do not make a volatile swap the headline demo.
+
+### 11.5 Build-order impact
+No new step — the same adapters (Mayan, deBridge) deliver both bridge and swap. Implement USDC bridge first (proves aggregation cleanly), then enable any-token quoting on Mayan/deBridge (mostly the same API with different in/out tokens).

--- a/prep-kits/solana-x402-bridge/LICENSE
+++ b/prep-kits/solana-x402-bridge/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 HFSP Labs / Clawdrop
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/prep-kits/solana-x402-bridge/PROVIDERS.md
+++ b/prep-kits/solana-x402-bridge/PROVIDERS.md
@@ -1,0 +1,59 @@
+# Bridge Providers — Adapter Specs (5 providers)
+
+The aggregator (`scripts/bridge-aggregator.ts`) ranks these **5 Solana → EVM** providers by net amount-out. Each implements the `BridgeProvider` interface in `scripts/providers.ts`: `supports()`, `quote()`, `execute()`, `status()`.
+
+> All endpoints/SDKs below are starting points — confirm versions against each provider's live docs before implementing. Normalize every quote into `ProviderQuote` (amountOutUSDC net of provider fee + gas, etaSeconds, reliabilityScore).
+
+---
+
+## 1. Circle CCTP — `cctp` (DEFAULT BENCHMARK)
+- **Why:** Native USDC burn-and-mint, **1:1, no slippage**, lowest cost. Every other provider is judged against this.
+- **SDK/API:** No price API — it's a protocol. Attestation service (Iris): `https://iris-api.circle.com` (`GET /v1/attestations/{messageHash}`; CCTP v2 supports fast transfers).
+- **Flow:** `depositForBurn` on source (Solana TokenMessenger program) → poll Iris for attestation → `receiveMessage` mint on destination EVM.
+- **quote():** amountOut ≈ amountIn − dest gas (− fast-transfer fee if CCTP v2 fast). reliabilityScore ~0.99.
+- **Solana:** CCTP programs deployed on Solana. Polygon: delivers **native** USDC (note USDC.e mismatch for Polymarket — may need a downstream swap).
+- **Docs:** https://developers.circle.com/stablecoins/docs/cctp-getting-started
+
+## 2. Mayan Finance — `mayan`
+- **Why:** Solana-native cross-chain (Swift / MCTP / Wormhole routes), strong Solana↔EVM coverage, fast.
+- **SDK/API:** `@mayanfinance/swap-sdk`; quote API `https://price-api.mayan.finance/v3/quote`.
+- **quote():** call quote API with fromChain=solana, toChain, fromToken=USDC, amount → returns route + expected out + fees. Pick best of returned routes.
+- **execute():** build + sign via SDK (`swapFromSolana`), returns source sig; track via Mayan explorer/status.
+- **status():** Mayan tracking API by source tx.
+- **Docs:** https://docs.mayan.finance
+
+## 3. deBridge (DLN) — `debridge`
+- **Why:** Fast intent-based liquidity network, native Solana↔EVM support.
+- **API:** `https://dln.debridge.finance/v1.0/dln/order/quote` (quote) and `/create-tx` (build).
+- **quote():** params srcChainId (Solana=7565164), dstChainId, srcTokenIn=USDC, amount → estimation with fees + recommended out.
+- **execute():** `/create-tx` returns the tx to sign on Solana; order filled by takers on destination.
+- **status():** order status endpoint by orderId.
+- **Docs:** https://docs.debridge.finance/dln-the-debridge-liquidity-network-protocol
+
+## 4. Wormhole / Portal — `wormhole`
+- **Why:** Canonical, battle-tested token bridge; CCTP route also available via Connect. Good fallback.
+- **SDK:** `@wormhole-foundation/sdk` (TS). For USDC, prefer its CCTP route; else token-bridge lock/mint.
+- **quote():** SDK route quoting; slower (guardian VAA ~ minutes for non-CCTP). Set higher etaSeconds, slightly lower reliabilityScore for wrapped routes.
+- **execute():** initiate transfer on Solana → fetch VAA → redeem on destination.
+- **status():** poll VAA / redeem status.
+- **Docs:** https://wormhole.com/docs/
+
+## 5. Allbridge (Core) — `allbridge`
+- **Why:** Stablecoin-focused Solana↔EVM pools; simple USDC routing.
+- **SDK/API:** `@allbridge/bridge-core-sdk`; API `https://core.api.allbridge.io`.
+- **quote():** SDK `getAmountToBeReceived` (accounts for pool fee + slippage) for USDC Solana→dest.
+- **execute():** SDK send (sign on Solana); pools settle on destination.
+- **status():** SDK/explorer status by tx.
+- **Docs:** https://docs.allbridge.io/
+
+---
+
+## Ranking inputs the aggregator expects from each adapter
+`{ provider, amountOutUSDC (net), bridgeFeeUSDC, bridgeFeeBps, networkFeesUSDC, etaSeconds, reliabilityScore, route }`
+
+## MVP order (24h)
+1. **CCTP** (benchmark) + **Mayan** (Solana-native) → prove aggregation with 2.
+2. Add **deBridge** → 3 providers = credible aggregator.
+3. Add **Wormhole** + **Allbridge** if time remains.
+
+The HFSP x402 relayer (gnosis-card-x402, generalized) is the **execution/fee layer**, not counted among the 5 external quote providers — it can also be registered as a 6th adapter that carries the integrator fee natively.

--- a/prep-kits/solana-x402-bridge/README.md
+++ b/prep-kits/solana-x402-bridge/README.md
@@ -1,23 +1,25 @@
 # solana-x402-bridge
 
-**Cross-chain execution for Solana agents.** Move USDC from Solana to any EVM chain via the HFSP x402 relayer, then act on it — bridge, then execute.
+**The Jupiter of cross-chain for Solana agents.** Aggregate every bridge, quote the best rate, optionally fund with fiat, and execute on any EVM chain — all from a Solana wallet.
 
-> One-line pitch: Let a Solana agent reach EVM markets — bridge USDC to any EVM chain and act on it, all from a Solana wallet.
+> One-line pitch: A Solana agent that shops every cross-chain route for the best rate, can be funded by card/bank via Onramper, and executes on EVM (Polymarket betting demo).
 
 ## Why this matters
 
-Solana agents are trapped on Solana. The biggest markets, prediction venues, and liquidity often live on EVM chains. There is **no cross-chain asset-bridge skill** in the Solana AI Kit ecosystem today. This package gives an agent a safe, fee-transparent way to bridge USDC and execute on the other side — with Polymarket betting as the flagship demo.
+Solana agents are trapped on Solana, and the few "bridge" attempts hardcode a single route. There is **no bridge-aggregator skill** in the Solana AI Kit ecosystem. This package shops **multiple bridge providers** (Circle CCTP, Mayan, deBridge, Wormhole, Allbridge, LI.FI, our x402 relayer), returns the best net rate, and proves it on screen — plus an **Onramper** fiat layer for funding and cash-out.
 
-**Solana is always the front door.** Every flow starts from a Solana wallet/agent; EVM is reached through the bridge.
+**Solana is always the front door.** Every flow starts from a Solana wallet/agent.
 
 ## Modules
 
 | Module | Purpose |
 |---|---|
-| `bridge-quote` | Route + transparent fee breakdown + ETA (read-only) |
-| `bridge-execute` | Pay via x402, bridge, return source + dest tx |
+| `bridge-aggregator` | Quote N bridge providers, rank by best net rate (the headline) |
+| `bridge-quote` | Returns the best route + full per-provider comparison |
+| `bridge-execute` | Pay via x402, route to the chosen provider, return source + dest tx |
 | `bridge-safety` | Allowlist, spend caps, slippage, stale-RPC freshness guard, confirmation monitor |
-| `evm-targets` | Supported EVM chains + token + endpoint registry |
+| `evm-targets` | Supported EVM chains + tokens + provider registry |
+| `fiat-onramp` | Fund with fiat / cash out via Onramper (20+ ranked providers) |
 | `polymarket-read` | Read Polymarket markets, odds, positions (demo layer) |
 | `polymarket-bet` | Place / redeem Polymarket bets (demo layer) |
 
@@ -25,14 +27,15 @@ Solana agents are trapped on Solana. The biggest markets, prediction venues, and
 
 ```bash
 # "Bet 5 USDC that <event> resolves YES on Polymarket"
-npx tsx scripts/bridge-quote.ts 5 polygon usdc      # route + fee + ETA
-npx tsx scripts/bridge-execute.ts 5 polygon usdc    # Solana -> Polygon (~45-90s)
+npx tsx scripts/bridge-quote.ts 5 polygon usdc      # aggregates providers -> best + comparison
+npx tsx scripts/bridge-execute.ts 5 polygon usdc    # routes best provider, Solana -> Polygon
 npx tsx scripts/polymarket.ts bet <marketId> YES 5  # bet on real market
+# optional: npx tsx scripts/onramp.ts quote USD 20 solana   # fund with fiat first
 ```
 
 ## Status
 
-This is a **prep kit / scaffold**. See `BUILD-BRIEF.md` for the full implementation spec. Core bridge logic is generalized from `packages/gnosis-card-x402`.
+**Prep kit / scaffold.** Full spec in `BUILD-BRIEF.md` (see §10 for the aggregation + Onramper design). Core bridge logic generalizes from `packages/gnosis-card-x402`.
 
 ## License
 

--- a/prep-kits/solana-x402-bridge/README.md
+++ b/prep-kits/solana-x402-bridge/README.md
@@ -1,0 +1,39 @@
+# solana-x402-bridge
+
+**Cross-chain execution for Solana agents.** Move USDC from Solana to any EVM chain via the HFSP x402 relayer, then act on it — bridge, then execute.
+
+> One-line pitch: Let a Solana agent reach EVM markets — bridge USDC to any EVM chain and act on it, all from a Solana wallet.
+
+## Why this matters
+
+Solana agents are trapped on Solana. The biggest markets, prediction venues, and liquidity often live on EVM chains. There is **no cross-chain asset-bridge skill** in the Solana AI Kit ecosystem today. This package gives an agent a safe, fee-transparent way to bridge USDC and execute on the other side — with Polymarket betting as the flagship demo.
+
+**Solana is always the front door.** Every flow starts from a Solana wallet/agent; EVM is reached through the bridge.
+
+## Modules
+
+| Module | Purpose |
+|---|---|
+| `bridge-quote` | Route + transparent fee breakdown + ETA (read-only) |
+| `bridge-execute` | Pay via x402, bridge, return source + dest tx |
+| `bridge-safety` | Allowlist, spend caps, slippage, stale-RPC freshness guard, confirmation monitor |
+| `evm-targets` | Supported EVM chains + token + endpoint registry |
+| `polymarket-read` | Read Polymarket markets, odds, positions (demo layer) |
+| `polymarket-bet` | Place / redeem Polymarket bets (demo layer) |
+
+## Demo (60s)
+
+```bash
+# "Bet 5 USDC that <event> resolves YES on Polymarket"
+npx tsx scripts/bridge-quote.ts 5 polygon usdc      # route + fee + ETA
+npx tsx scripts/bridge-execute.ts 5 polygon usdc    # Solana -> Polygon (~45-90s)
+npx tsx scripts/polymarket.ts bet <marketId> YES 5  # bet on real market
+```
+
+## Status
+
+This is a **prep kit / scaffold**. See `BUILD-BRIEF.md` for the full implementation spec. Core bridge logic is generalized from `packages/gnosis-card-x402`.
+
+## License
+
+MIT

--- a/prep-kits/solana-x402-bridge/RELAYER-DEPLOY.md
+++ b/prep-kits/solana-x402-bridge/RELAYER-DEPLOY.md
@@ -1,0 +1,43 @@
+# RELAYER-DEPLOY.md — Multi-EVM x402 Relayer
+
+Generalize `packages/gnosis-card-x402` (currently Solana/Base USDC → Gnosis) into a multi-EVM relayer that backs `bridge-execute` and carries the integrator fee natively.
+
+## Role in the system
+The relayer is the **execution + fee layer**, not one of the 5 quote providers. The open-source skill is a thin client; the relayer holds keys, applies the fee, and settles on the destination chain. Forking the skill can't strip the fee because it lives here.
+
+## Endpoints (HTTP + x402)
+| Method | Path | Purpose |
+|---|---|---|
+| GET  | `/quote`        | route + disclosed fee + ETA for (srcToken, amountIn, destChain, destToken) |
+| GET  | `/targets`      | supported chains + tokens (mirror of evm-targets) |
+| POST | `/execute`      | x402-paid; perform bridge/swap; returns `{sourceTx, destTx, statusId}` |
+| GET  | `/status/:id`   | settlement status (poll until `settled`) |
+
+`/execute` requires the x402 payment header (`X-Payment: <solana-tx-sig>`, `X-Payment-Chain: solana`) — reuse the exact intake flow already in `gnosis-card-x402/src/index.ts`.
+
+## Generalize from gnosis-card-x402
+1. **Chain registry** (`src/config.ts`): turn the single Gnosis target into a map keyed by chain → `{ chainId, rpcUrl, usdcAddress, finalitySeconds }`. Seed: polygon, gnosis (existing), base, arbitrum, ethereum.
+2. **Settlement adapters**: factor the Gnosis settlement into a `SettlementAdapter` per destination so a new chain = new adapter. For USDC prefer **CCTP** mint on destination; for swaps delegate to Mayan/deBridge.
+3. **Multi-token**: accept `srcToken`/`destToken`; for swaps return `priceImpactBps` + `minAmountOut` from the underlying provider quote.
+4. **Health**: reuse `getHealthyEvmRpc()` logic server-side per destination before settling.
+
+## Fee configuration (the monetization)
+- Env: `INTEGRATOR_FEE_BPS` (default 15), `INTEGRATOR_FEE_ACCOUNT` (default HFSP wallet).
+- `/quote` MUST return the fee line explicitly. Never hide it.
+- Fee applied as the x402 price of `/execute`. Configurable per-integrator (Jupiter referral pattern) so partners can set their own and forkers are invited to integrate rather than strip.
+- Keep total take ≤ 25 bps to stay attractive.
+
+## Optional: register the relayer as a 6th aggregator adapter
+If you want the relayer quoted alongside the 5 external providers, add an `hfsp` adapter in `scripts/providers.ts` whose `quote()` calls `GET /quote` and whose `execute()` calls `POST /execute`. It will compete on net rate like any provider, but its quote already includes the integrator fee. Keep it OUT of the "best 5 external routes" comparison shown to judges to avoid the appearance of self-dealing — surface it as "our relayer route" separately.
+
+## Deploy
+- Hosting: existing HFSP VPS (72.62.239.63) behind nginx, or containerize from `docker-compose`.
+- DNS: `bridge.clawdrop.live` → relayer (Hostinger). Matches `X402_RELAYER_URL` default in `.env.example`.
+- Secrets: relayer holds the EVM + Solana settlement keys (NEVER in the skill repo).
+- TLS via Let's Encrypt (same pattern as clawdrop.live).
+
+## Acceptance
+- [ ] `/quote` returns correct fee-disclosed quotes for USDC bridge + a SOL→ETH swap.
+- [ ] `/execute` settles a small USDC transfer to Polygon and returns both tx hashes.
+- [ ] `/targets` lists ≥3 EVM chains incl. Polygon.
+- [ ] Fee bps + account are env-configurable and shown in every quote.

--- a/prep-kits/solana-x402-bridge/SKILL.md
+++ b/prep-kits/solana-x402-bridge/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: solana-x402-bridge
+description: Cross-chain execution for Solana agents. Use when a Solana agent needs to move USDC to an EVM chain (Polygon, Gnosis, Base, Arbitrum) and act on it — including reading and betting on Polymarket. Routes through the HFSP x402 relayer with transparent fees and safety guardrails. Triggers include "bridge USDC", "send to Polygon/EVM", "bet on Polymarket", "cross-chain", "reach EVM market from Solana".
+---
+
+# solana-x402-bridge
+
+Router skill for cross-chain execution from Solana to EVM. Load the relevant module:
+
+1. **Quoting a bridge?** → `skills/bridge-quote` — always quote first; surfaces the disclosed fee.
+2. **Executing a bridge?** → `skills/bridge-execute` — only after a quote + safety check.
+3. **Safety / preflight?** → `skills/bridge-safety` — ALWAYS run before execute. Allowlist, caps, slippage, RPC freshness.
+4. **Which chains/tokens?** → `skills/evm-targets`.
+5. **Reading Polymarket?** → `skills/polymarket-read`.
+6. **Placing a Polymarket bet?** → `skills/polymarket-bet` — bridge to Polygon first.
+
+## Golden rules
+- Solana is the front door: every flow originates from a Solana wallet.
+- Never `bridge-execute` without a passing `bridge-safety` preflight.
+- Never act on a stale RPC read — `bridge-safety` enforces the freshness guard.
+- The fee is charged by the relayer (x402) and is always shown in `bridge-quote`. Never hide it.

--- a/prep-kits/solana-x402-bridge/SKILL.md
+++ b/prep-kits/solana-x402-bridge/SKILL.md
@@ -1,21 +1,24 @@
 ---
 name: solana-x402-bridge
-description: Cross-chain execution for Solana agents. Use when a Solana agent needs to move USDC to an EVM chain (Polygon, Gnosis, Base, Arbitrum) and act on it — including reading and betting on Polymarket. Routes through the HFSP x402 relayer with transparent fees and safety guardrails. Triggers include "bridge USDC", "send to Polygon/EVM", "bet on Polymarket", "cross-chain", "reach EVM market from Solana".
+description: The Jupiter of cross-chain for Solana agents. Use when a Solana agent needs the best-rate bridge of USDC to an EVM chain (Polygon, Gnosis, Base, Arbitrum), wants to be funded with fiat, or needs to read/bet on Polymarket. Aggregates multiple bridge providers (CCTP, Mayan, deBridge, Wormhole, Allbridge, LI.FI, x402) and Onramper for fiat. Triggers: "best bridge rate", "bridge USDC", "compare bridges", "fund with fiat", "onramp", "bet on Polymarket", "cross-chain".
 ---
 
 # solana-x402-bridge
 
-Router skill for cross-chain execution from Solana to EVM. Load the relevant module:
+Router skill for best-rate cross-chain execution from Solana to EVM. Load the relevant module:
 
-1. **Quoting a bridge?** → `skills/bridge-quote` — always quote first; surfaces the disclosed fee.
-2. **Executing a bridge?** → `skills/bridge-execute` — only after a quote + safety check.
-3. **Safety / preflight?** → `skills/bridge-safety` — ALWAYS run before execute. Allowlist, caps, slippage, RPC freshness.
-4. **Which chains/tokens?** → `skills/evm-targets`.
-5. **Reading Polymarket?** → `skills/polymarket-read`.
-6. **Placing a Polymarket bet?** → `skills/polymarket-bet` — bridge to Polygon first.
+1. **Want the best route / compare bridges?** → `skills/bridge-aggregator` (quotes all providers).
+2. **Quoting a transfer?** → `skills/bridge-quote` — returns aggregated best + comparison. Quote first.
+3. **Executing?** → `skills/bridge-execute` — only after a quote + safety check; routes to the winning provider.
+4. **Safety / preflight?** → `skills/bridge-safety` — ALWAYS before execute. Allowlist, caps, slippage, RPC freshness.
+5. **Which chains/tokens/providers?** → `skills/evm-targets`.
+6. **Fund with fiat / cash out?** → `skills/fiat-onramp` (Onramper).
+7. **Reading Polymarket?** → `skills/polymarket-read`.
+8. **Placing a Polymarket bet?** → `skills/polymarket-bet` — bridge to Polygon first.
 
 ## Golden rules
 - Solana is the front door: every flow originates from a Solana wallet.
+- Always aggregate — return the per-provider comparison, never a single hardcoded route.
 - Never `bridge-execute` without a passing `bridge-safety` preflight.
 - Never act on a stale RPC read — `bridge-safety` enforces the freshness guard.
-- The fee is charged by the relayer (x402) and is always shown in `bridge-quote`. Never hide it.
+- Every fee (bridge providers, integrator, Onramper) is quoted and disclosed. Never hidden.

--- a/prep-kits/solana-x402-bridge/TEST-PLAN.md
+++ b/prep-kits/solana-x402-bridge/TEST-PLAN.md
@@ -1,0 +1,68 @@
+# TEST-PLAN.md — solana-x402-bridge
+
+Small-amount, reproducible runs that double as the demo. Use tiny sizes; this moves real funds.
+
+## 0. Prereqs
+- `.env` filled: Solana RPC (+ fallbacks), per-chain EVM RPC (+ fallbacks), `X402_RELAYER_URL`, fee config, caps, `ONRAMPER_API_KEY` (optional).
+- Demo wallets funded with small amounts (e.g. 5 USDC on Solana; ~0.02 SOL for the swap test).
+- `npm install` in the skill package.
+
+## 1. Aggregation correctness (USDC bridge) — the headline
+```bash
+npx tsx scripts/bridge-quote.ts USDC 5 polygon USDC
+```
+Expect: `BEST (bridge)` plus a ranked COMPARISON across eligible providers (cctp, mayan, debridge, wormhole, allbridge).
+Pass: CCTP appears with `priceImpactBps: 0`; fee line disclosed; ranking sorted by net `amountOut`.
+
+## 2. Cross-chain swap quote (SOL → ETH) — second capability
+```bash
+npx tsx scripts/bridge-quote.ts SOL 0.1 ethereum ETH
+```
+Expect: eligible set narrows to **mayan + debridge** only (cctp/allbridge/wormhole filtered by supportsPair).
+Pass: each quote shows `kind: "swap"`, non-zero `priceImpactBps`, and a `minAmountOut`.
+
+## 3. Safety preflight — must BLOCK bad states
+Run each and confirm it fails loud:
+```bash
+# a) destination not allowlisted
+DEST_ALLOWLIST=gnosis npx tsx scripts/bridge-execute.ts USDC 5 polygon USDC      # -> blocked: not in allowlist
+# b) over per-tx cap
+MAX_BRIDGE_USDC_PER_TX=1 npx tsx scripts/bridge-execute.ts USDC 5 polygon USDC    # -> blocked: exceeds cap
+# c) stale/dead Solana RPC (point primary at a bad URL, no fallback)
+SOLANA_RPC_URL=https://api.invalid SOLANA_FALLBACK_RPCS= npx tsx scripts/bridge-execute.ts USDC 5 polygon USDC  # -> blocked: Solana RPC
+# d) dead EVM RPC
+POLYGON_RPC_URL=https://api.invalid POLYGON_FALLBACK_RPCS= npx tsx scripts/bridge-execute.ts USDC 5 polygon USDC # -> blocked: polygon RPC
+```
+Pass: every case returns "Safety preflight failed: ..." and does NOT execute.
+
+## 4. RPC failover — must RECOVER
+```bash
+# bad primary + good fallback => should succeed via fallback, slotLag within bound
+SOLANA_RPC_URL=https://api.invalid \
+SOLANA_FALLBACK_RPCS=$GOOD_SOLANA_RPC \
+npx tsx scripts/bridge-quote.ts USDC 5 polygon USDC
+```
+Pass: quote succeeds; switcher selected the healthy fallback. Repeat for `POLYGON_RPC_URL` + `POLYGON_FALLBACK_RPCS`.
+
+## 5. Execute (real, small) — USDC Solana → Polygon
+```bash
+npx tsx scripts/bridge-execute.ts USDC 5 polygon USDC
+```
+Pass: returns `{sourceTx, destTx, statusId}` + explorer links; USDC arrives on Polygon (~45–90s). NOTE the USDC.e vs native-USDC handling for the Polymarket leg.
+
+## 6. Polymarket demo
+```bash
+npx tsx scripts/polymarket.ts read worldcup        # list markets + odds
+npx tsx scripts/polymarket.ts bet <marketId> YES 5 # place small bet
+```
+Pass: market list returns odds; bet returns a position.
+
+## 7. Optional — fiat funnel (Onramper)
+```bash
+npx tsx scripts/onramp.ts quote USD 20 solana      # best ranked fiat->USDC quote, fee disclosed
+```
+Pass: returns a ranked provider quote with disclosed fee.
+
+## Demo recording order (60s)
+Step 1 (aggregation) → step 3c (safety blocks stale RPC) → step 5 (execute) → step 6 (bet).
+That sequence shows: best-rate aggregation, safety, real settlement, real action — the full story.

--- a/prep-kits/solana-x402-bridge/examples/demo/cross-chain-bet.md
+++ b/prep-kits/solana-x402-bridge/examples/demo/cross-chain-bet.md
@@ -1,0 +1,32 @@
+# 60-Second Demo: Solana → Polygon → Polymarket bet
+
+**Narrative:** A Solana agent bets on a real Polymarket market — initiated entirely from a Solana wallet.
+
+## Setup
+- `.env` filled (Solana RPC + demo wallet, Polygon RPC + demo EVM wallet, relayer URL).
+- Small amounts only (e.g. 5 USDC).
+
+## Script
+1. **Prompt:** "Bet 5 USDC that <event> resolves YES on Polymarket."
+2. **Quote** — show route + transparent fee:
+   ```bash
+   npx tsx scripts/bridge-quote.ts 5 polygon usdc
+   ```
+   → `bridgeFee: 0.0075 USDC (15 bps)`, `etaSeconds: 45`.
+3. **Safety preflight** — show it passing (within caps, RPC fresh, polygon allowlisted).
+4. **Execute** — Solana → Polygon:
+   ```bash
+   npx tsx scripts/bridge-execute.ts 5 polygon usdc
+   ```
+   → print Solana + Polygon explorer links (~45–90s).
+5. **Bet** — on a real market:
+   ```bash
+   npx tsx scripts/polymarket.ts bet <marketId> YES 5
+   ```
+   → show resulting position.
+6. **Close:** "One Solana wallet. One skill. Cross-chain execution. No bridge skill like this exists in the kit."
+
+## Judge talking points
+- White space: no real cross-chain bridge skill in 158 submissions.
+- Safety-first: guardrails + transparent fee on money movement.
+- Solana-native front door; EVM reached through the bridge.

--- a/prep-kits/solana-x402-bridge/package.json
+++ b/prep-kits/solana-x402-bridge/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "solana-x402-bridge-skill",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Cross-chain execution skill for Solana agents — bridge USDC to any EVM via x402, then execute (Polymarket demo).",
+  "type": "module",
+  "license": "MIT",
+  "scripts": {
+    "quote": "tsx scripts/bridge-quote.ts",
+    "execute": "tsx scripts/bridge-execute.ts",
+    "targets": "tsx scripts/evm-targets.ts",
+    "polymarket": "tsx scripts/polymarket.ts"
+  },
+  "dependencies": {
+    "@solana/web3.js": "^1.95.0",
+    "viem": "^2.21.0"
+  },
+  "devDependencies": {
+    "tsx": "^4.19.0",
+    "typescript": "^5.6.0"
+  }
+}

--- a/prep-kits/solana-x402-bridge/package.json
+++ b/prep-kits/solana-x402-bridge/package.json
@@ -2,13 +2,14 @@
   "name": "solana-x402-bridge-skill",
   "version": "0.1.0",
   "private": true,
-  "description": "Cross-chain execution skill for Solana agents — bridge USDC to any EVM via x402, then execute (Polymarket demo).",
+  "description": "The Jupiter of cross-chain for Solana agents — aggregate bridges for best rate, fund via Onramper, execute on EVM (Polymarket demo).",
   "type": "module",
   "license": "MIT",
   "scripts": {
     "quote": "tsx scripts/bridge-quote.ts",
     "execute": "tsx scripts/bridge-execute.ts",
     "targets": "tsx scripts/evm-targets.ts",
+    "onramp": "tsx scripts/onramp.ts",
     "polymarket": "tsx scripts/polymarket.ts"
   },
   "dependencies": {

--- a/prep-kits/solana-x402-bridge/scripts/bridge-aggregator.ts
+++ b/prep-kits/solana-x402-bridge/scripts/bridge-aggregator.ts
@@ -1,20 +1,25 @@
-// Aggregate all providers; return best net route + ranked comparison.
+// Aggregate providers for a bridge (USDC->USDC) OR cross-chain swap (e.g. SOL->ETH).
+// Returns best net route + ranked comparison. Eligibility via each adapter's supports().
 import { PROVIDERS, type ProviderQuote } from "./providers.js";
 import type { EvmChain } from "./types.js";
 
-export async function aggregate(amountUSDC: number, chain: EvmChain, token = "usdc") {
+export async function aggregate(
+  srcToken: string,
+  amountIn: number,
+  destChain: EvmChain,
+  destToken: string,
+) {
   const maxEta = Number(process.env.MAX_BRIDGE_ETA_SECONDS ?? 300);
-  const active = Object.values(PROVIDERS).filter((p): p is NonNullable<typeof p> => !!p && p.supports(chain, token));
+  const active = Object.values(PROVIDERS).filter((p) => p.supportsPair(srcToken, destChain, destToken));
 
   const quotes: ProviderQuote[] = [];
   await Promise.all(active.map(async (p) => {
-    try { quotes.push(await p.quote(amountUSDC, chain, token)); } catch { /* skip failed provider */ }
+    try { quotes.push(await p.quote(srcToken, amountIn, destChain, destToken)); } catch { /* skip failed */ }
   }));
 
   const eligible = quotes
     .filter((q) => q.etaSeconds <= maxEta && q.reliabilityScore >= 0.5)
-    .sort((a, b) => b.amountOutUSDC - a.amountOutUSDC); // best net out first
+    .sort((a, b) => b.amountOut - a.amountOut); // best net out (in destToken) first
 
-  // TODO(devin): integrator fee already folded into each quote's amountOut by the adapter (or add here once).
   return { best: eligible[0] ?? null, ranked: eligible };
 }

--- a/prep-kits/solana-x402-bridge/scripts/bridge-aggregator.ts
+++ b/prep-kits/solana-x402-bridge/scripts/bridge-aggregator.ts
@@ -1,0 +1,20 @@
+// Aggregate all providers; return best net route + ranked comparison.
+import { PROVIDERS, type ProviderQuote } from "./providers.js";
+import type { EvmChain } from "./types.js";
+
+export async function aggregate(amountUSDC: number, chain: EvmChain, token = "usdc") {
+  const maxEta = Number(process.env.MAX_BRIDGE_ETA_SECONDS ?? 300);
+  const active = Object.values(PROVIDERS).filter((p): p is NonNullable<typeof p> => !!p && p.supports(chain, token));
+
+  const quotes: ProviderQuote[] = [];
+  await Promise.all(active.map(async (p) => {
+    try { quotes.push(await p.quote(amountUSDC, chain, token)); } catch { /* skip failed provider */ }
+  }));
+
+  const eligible = quotes
+    .filter((q) => q.etaSeconds <= maxEta && q.reliabilityScore >= 0.5)
+    .sort((a, b) => b.amountOutUSDC - a.amountOutUSDC); // best net out first
+
+  // TODO(devin): integrator fee already folded into each quote's amountOut by the adapter (or add here once).
+  return { best: eligible[0] ?? null, ranked: eligible };
+}

--- a/prep-kits/solana-x402-bridge/scripts/bridge-execute.ts
+++ b/prep-kits/solana-x402-bridge/scripts/bridge-execute.ts
@@ -1,17 +1,21 @@
-// usage: tsx scripts/bridge-execute.ts <amountUSDC> <destChain> <destToken=usdc>
-// Quote -> safety preflight -> x402 pay -> relayer execute -> poll status.
+// usage: tsx scripts/bridge-execute.ts <srcToken> <amountIn> <destChain> <destToken>
+// Aggregate -> safety preflight (both chains) -> route to best provider -> poll status.
 import { preflight } from "./bridge-safety.js";
+import { aggregate } from "./bridge-aggregator.js";
+import { PROVIDERS } from "./providers.js";
+import type { EvmChain } from "./types.js";
 
-async function execute(amount: number, chain: string, token = "usdc") {
-  const safety = await preflight(amount, chain);
+async function execute(srcToken: string, amountIn: number, chain: EvmChain, destToken: string) {
+  const safety = await preflight(srcToken, amountIn, chain, destToken);
   if (!safety.ok) throw new Error("Safety preflight failed: " + safety.failures.join("; "));
-  // TODO(devin):
-  // 1. pay relayer via x402 (USDC on Solana) — see packages/gnosis-card-x402 X-Payment flow
-  // 2. POST `${X402_RELAYER_URL}/execute` with payment header + {amount, chain, token}
-  // 3. poll `${X402_RELAYER_URL}/status/:id` until settled
-  // 4. return BridgeResult with both explorer links
-  throw new Error("TODO: implement execute (reuse gnosis-card-x402 settlement flow)");
+
+  const { best } = await aggregate(srcToken, amountIn, chain, destToken);
+  if (!best) throw new Error("No eligible route");
+
+  const provider = PROVIDERS[best.provider];
+  // TODO(devin): pay relayer via x402 if routing through HFSP; else execute via provider adapter.
+  return provider.execute(srcToken, amountIn, chain, destToken);
 }
 
-const [amount, chain, token] = process.argv.slice(2);
-execute(Number(amount), chain, token).then((r) => console.log(JSON.stringify(r, null, 2)));
+const [srcToken, amountIn, chain, destToken] = process.argv.slice(2);
+execute(srcToken, Number(amountIn), chain as EvmChain, destToken).then((r) => console.log(JSON.stringify(r, null, 2)));

--- a/prep-kits/solana-x402-bridge/scripts/bridge-execute.ts
+++ b/prep-kits/solana-x402-bridge/scripts/bridge-execute.ts
@@ -1,0 +1,17 @@
+// usage: tsx scripts/bridge-execute.ts <amountUSDC> <destChain> <destToken=usdc>
+// Quote -> safety preflight -> x402 pay -> relayer execute -> poll status.
+import { preflight } from "./bridge-safety.js";
+
+async function execute(amount: number, chain: string, token = "usdc") {
+  const safety = await preflight(amount, chain);
+  if (!safety.ok) throw new Error("Safety preflight failed: " + safety.failures.join("; "));
+  // TODO(devin):
+  // 1. pay relayer via x402 (USDC on Solana) — see packages/gnosis-card-x402 X-Payment flow
+  // 2. POST `${X402_RELAYER_URL}/execute` with payment header + {amount, chain, token}
+  // 3. poll `${X402_RELAYER_URL}/status/:id` until settled
+  // 4. return BridgeResult with both explorer links
+  throw new Error("TODO: implement execute (reuse gnosis-card-x402 settlement flow)");
+}
+
+const [amount, chain, token] = process.argv.slice(2);
+execute(Number(amount), chain, token).then((r) => console.log(JSON.stringify(r, null, 2)));

--- a/prep-kits/solana-x402-bridge/scripts/bridge-quote.ts
+++ b/prep-kits/solana-x402-bridge/scripts/bridge-quote.ts
@@ -1,0 +1,12 @@
+// usage: tsx scripts/bridge-quote.ts <amountUSDC> <destChain> <destToken=usdc>
+// Calls the relayer /quote. MUST surface the fee breakdown. Read-only.
+import type { BridgeQuote } from "./types.js";
+
+async function quote(amount: number, chain: string, token = "usdc"): Promise<BridgeQuote> {
+  // TODO(devin): GET `${X402_RELAYER_URL}/quote?amount=${amount}&chain=${chain}&token=${token}`
+  // Relayer applies INTEGRATOR_FEE_BPS / INTEGRATOR_FEE_ACCOUNT. Return the disclosed breakdown.
+  throw new Error("TODO: implement against relayer /quote (generalize gnosis-card-x402)");
+}
+
+const [amount, chain, token] = process.argv.slice(2);
+quote(Number(amount), chain, token).then((q) => console.log(JSON.stringify(q, null, 2)));

--- a/prep-kits/solana-x402-bridge/scripts/bridge-quote.ts
+++ b/prep-kits/solana-x402-bridge/scripts/bridge-quote.ts
@@ -1,12 +1,12 @@
 // usage: tsx scripts/bridge-quote.ts <amountUSDC> <destChain> <destToken=usdc>
-// Calls the relayer /quote. MUST surface the fee breakdown. Read-only.
-import type { BridgeQuote } from "./types.js";
-
-async function quote(amount: number, chain: string, token = "usdc"): Promise<BridgeQuote> {
-  // TODO(devin): GET `${X402_RELAYER_URL}/quote?amount=${amount}&chain=${chain}&token=${token}`
-  // Relayer applies INTEGRATOR_FEE_BPS / INTEGRATOR_FEE_ACCOUNT. Return the disclosed breakdown.
-  throw new Error("TODO: implement against relayer /quote (generalize gnosis-card-x402)");
-}
+// Aggregates all bridge providers and returns the BEST route + the full comparison.
+import { aggregate } from "./bridge-aggregator.js";
+import type { EvmChain } from "./types.js";
 
 const [amount, chain, token] = process.argv.slice(2);
-quote(Number(amount), chain, token).then((q) => console.log(JSON.stringify(q, null, 2)));
+aggregate(Number(amount), chain as EvmChain, token).then(({ best, ranked }) => {
+  if (!best) { console.log("No eligible route."); return; }
+  console.log("BEST:", JSON.stringify(best, null, 2));
+  console.log("\nCOMPARISON (ranked, net of fees):");
+  for (const q of ranked) console.log(`  ${q.provider.padEnd(10)} out=${q.amountOutUSDC} fee=${q.bridgeFeeUSDC} eta=${q.etaSeconds}s`);
+});

--- a/prep-kits/solana-x402-bridge/scripts/bridge-quote.ts
+++ b/prep-kits/solana-x402-bridge/scripts/bridge-quote.ts
@@ -1,12 +1,14 @@
-// usage: tsx scripts/bridge-quote.ts <amountUSDC> <destChain> <destToken=usdc>
-// Aggregates all bridge providers and returns the BEST route + the full comparison.
+// usage: tsx scripts/bridge-quote.ts <srcToken> <amountIn> <destChain> <destToken>
+//   bridge: tsx scripts/bridge-quote.ts USDC 5 polygon USDC
+//   swap:   tsx scripts/bridge-quote.ts SOL 1 ethereum ETH
 import { aggregate } from "./bridge-aggregator.js";
 import type { EvmChain } from "./types.js";
 
-const [amount, chain, token] = process.argv.slice(2);
-aggregate(Number(amount), chain as EvmChain, token).then(({ best, ranked }) => {
-  if (!best) { console.log("No eligible route."); return; }
-  console.log("BEST:", JSON.stringify(best, null, 2));
-  console.log("\nCOMPARISON (ranked, net of fees):");
-  for (const q of ranked) console.log(`  ${q.provider.padEnd(10)} out=${q.amountOutUSDC} fee=${q.bridgeFeeUSDC} eta=${q.etaSeconds}s`);
+const [srcToken, amountIn, destChain, destToken] = process.argv.slice(2);
+aggregate(srcToken, Number(amountIn), destChain as EvmChain, destToken).then(({ best, ranked }) => {
+  if (!best) { console.log("No eligible route for this pair."); return; }
+  console.log(`BEST (${best.kind}):`, JSON.stringify(best, null, 2));
+  console.log("\nCOMPARISON (ranked, net of fees + impact):");
+  for (const q of ranked)
+    console.log(`  ${q.provider.padEnd(10)} out=${q.amountOut} ${q.destToken} impact=${q.priceImpactBps}bps eta=${q.etaSeconds}s`);
 });

--- a/prep-kits/solana-x402-bridge/scripts/bridge-safety.ts
+++ b/prep-kits/solana-x402-bridge/scripts/bridge-safety.ts
@@ -1,0 +1,20 @@
+// Mandatory preflight. Fail loud; never silently proceed.
+import { getHealthyConnection } from "./rpc-health.js";
+import type { SafetyResult } from "./types.js";
+
+export async function preflight(amount: number, chain: string): Promise<SafetyResult> {
+  const failures: string[] = [];
+  const allow = (process.env.DEST_ALLOWLIST ?? "").split(",").map((s) => s.trim());
+  const maxTx = Number(process.env.MAX_BRIDGE_USDC_PER_TX ?? 100);
+
+  if (!allow.includes(chain)) failures.push(`destination '${chain}' not in allowlist`);
+  if (amount > maxTx) failures.push(`amount ${amount} exceeds per-tx cap ${maxTx}`);
+
+  const { connection, slotLag, endpoint } = await getHealthyConnection();
+  const maxLag = Number(process.env.RPC_MAX_SLOT_LAG ?? 150);
+  if (slotLag > maxLag) failures.push(`RPC slot-lag ${slotLag} > ${maxLag} (stale state)`);
+
+  // TODO(devin): daily-cap accounting (persist 24h rolling total), min amountOut / slippage check,
+  //              and post-execute confirmation monitor on both chains.
+  return { ok: failures.length === 0, failures, rpcSlotLag: slotLag, usedRpc: endpoint };
+}

--- a/prep-kits/solana-x402-bridge/scripts/bridge-safety.ts
+++ b/prep-kits/solana-x402-bridge/scripts/bridge-safety.ts
@@ -1,20 +1,26 @@
 // Mandatory preflight. Fail loud; never silently proceed.
-import { getHealthyConnection } from "./rpc-health.js";
+// Checks BOTH chains' RPC health (source Solana + destination EVM) before any execution.
+import { getHealthySolana, getHealthyEvmRpc } from "./rpc-health.js";
 import type { SafetyResult } from "./types.js";
 
-export async function preflight(amount: number, chain: string): Promise<SafetyResult> {
+export async function preflight(srcToken: string, amountIn: number, chain: string, destToken: string): Promise<SafetyResult> {
   const failures: string[] = [];
   const allow = (process.env.DEST_ALLOWLIST ?? "").split(",").map((s) => s.trim());
   const maxTx = Number(process.env.MAX_BRIDGE_USDC_PER_TX ?? 100);
 
   if (!allow.includes(chain)) failures.push(`destination '${chain}' not in allowlist`);
-  if (amount > maxTx) failures.push(`amount ${amount} exceeds per-tx cap ${maxTx}`);
+  if (srcToken.toLowerCase() === "usdc" && amountIn > maxTx) failures.push(`amount ${amountIn} exceeds per-tx cap ${maxTx}`);
 
-  const { connection, slotLag, endpoint } = await getHealthyConnection();
-  const maxLag = Number(process.env.RPC_MAX_SLOT_LAG ?? 150);
-  if (slotLag > maxLag) failures.push(`RPC slot-lag ${slotLag} > ${maxLag} (stale state)`);
+  // Source: Solana RPC health (lowest slot-lag healthy endpoint, else fail).
+  let slotLag = -1, usedRpc = "";
+  try { const s = await getHealthySolana(); slotLag = s.slotLag; usedRpc = s.endpoint; }
+  catch (e) { failures.push(`Solana RPC: ${(e as Error).message}`); }
 
-  // TODO(devin): daily-cap accounting (persist 24h rolling total), min amountOut / slippage check,
-  //              and post-execute confirmation monitor on both chains.
-  return { ok: failures.length === 0, failures, rpcSlotLag: slotLag, usedRpc: endpoint };
+  // Destination: EVM RPC health (auto-failover; fail if all stale/unreachable).
+  try { await getHealthyEvmRpc(chain); }
+  catch (e) { failures.push(`${chain} RPC: ${(e as Error).message}`); }
+
+  // TODO(devin): daily-cap accounting; for swaps (srcToken!=destToken) enforce minAmountOut /
+  //              slippage tolerance + re-quote before execute; post-execute confirmation on both chains.
+  return { ok: failures.length === 0, failures, rpcSlotLag: slotLag, usedRpc };
 }

--- a/prep-kits/solana-x402-bridge/scripts/evm-targets.ts
+++ b/prep-kits/solana-x402-bridge/scripts/evm-targets.ts
@@ -1,0 +1,9 @@
+// Registry of supported EVM destinations. Print with: tsx scripts/evm-targets.ts
+export const EVM_TARGETS = {
+  polygon:  { chainId: 137,   finalitySeconds: 45, tokens: { USDC_E: "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174" }, note: "Polymarket uses USDC.e" },
+  gnosis:   { chainId: 100,   finalitySeconds: 90, tokens: { USDC:   "0xDDAfbb505ad214D7b80b1f830fcCc89B60fb7A83" }, note: "live via gnosis-card-x402" },
+  base:     { chainId: 8453,  finalitySeconds: 30, tokens: { USDC:   "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913" } },
+  arbitrum: { chainId: 42161, finalitySeconds: 30, tokens: { USDC:   "0xaf88d065e77c8cC2239327C5EDb3A432268e5831" } },
+} as const;
+
+if (import.meta.url === `file://${process.argv[1]}`) console.log(JSON.stringify(EVM_TARGETS, null, 2));

--- a/prep-kits/solana-x402-bridge/scripts/onramp.ts
+++ b/prep-kits/solana-x402-bridge/scripts/onramp.ts
@@ -1,0 +1,17 @@
+// usage:
+//   tsx scripts/onramp.ts quote <fiat> <amount> <deliverChain>   # fiat -> USDC
+//   tsx scripts/onramp.ts offramp <amountUSDC> <fiat>            # USDC -> fiat
+// Onramper aggregates 20+ on/off-ramp providers; returns best ranked quote (fee disclosed).
+async function quote(fiat: string, amount: number, deliverChain: string) {
+  // TODO(devin): call Onramper API (ONRAMPER_API_KEY, signed). Return best provider quote + full fee.
+  // Deliver USDC to Solana or directly to the destination EVM chain.
+  throw new Error("TODO: implement Onramper onramp quote");
+}
+async function offramp(amountUSDC: number, fiat: string) {
+  // TODO(devin): Onramper offramp quote (USDC -> fiat) for cashing out winnings.
+  throw new Error("TODO: implement Onramper offramp quote");
+}
+const [cmd, ...rest] = process.argv.slice(2);
+if (cmd === "quote") quote(rest[0], Number(rest[1]), rest[2]);
+else if (cmd === "offramp") offramp(Number(rest[0]), rest[1]);
+else console.log("usage: quote <fiat> <amount> <deliverChain> | offramp <amountUSDC> <fiat>");

--- a/prep-kits/solana-x402-bridge/scripts/polymarket.ts
+++ b/prep-kits/solana-x402-bridge/scripts/polymarket.ts
@@ -1,0 +1,17 @@
+// usage:
+//   tsx scripts/polymarket.ts read [keyword]
+//   tsx scripts/polymarket.ts bet <marketId> <YES|NO> <amountUSDC>
+// Polymarket runs on Polygon (USDC.e). Reuse existing partial implementation.
+async function read(keyword?: string) {
+  // TODO(devin): GET ${POLYMARKET_API_URL} CLOB markets; filter by keyword; return odds/liquidity/status.
+  throw new Error("TODO: implement Polymarket read via CLOB API");
+}
+async function bet(marketId: string, outcome: string, amount: number) {
+  // TODO(devin): ensure USDC.e on Polygon (else trigger bridge), then place CLOB order; return position.
+  throw new Error("TODO: implement Polymarket bet (reuse partial code)");
+}
+
+const [cmd, ...rest] = process.argv.slice(2);
+if (cmd === "read") read(rest[0]);
+else if (cmd === "bet") bet(rest[0], rest[1], Number(rest[2]));
+else console.log("usage: read [keyword] | bet <marketId> <YES|NO> <amountUSDC>");

--- a/prep-kits/solana-x402-bridge/scripts/providers.ts
+++ b/prep-kits/solana-x402-bridge/scripts/providers.ts
@@ -1,9 +1,10 @@
-// Bridge provider adapters. Add a provider = add one object implementing BridgeProvider.
+// Bridge provider adapters — 5 Solana -> EVM providers ranked by the aggregator.
+// Spec for each: see PROVIDERS.md. Add a provider = add one adapter implementing BridgeProvider.
 import type { BridgeQuote, BridgeResult, EvmChain } from "./types.js";
 
 export interface ProviderQuote extends BridgeQuote {
   provider: string;
-  reliabilityScore: number; // 0..1, used by aggregator filter
+  reliabilityScore: number; // 0..1 — aggregator filters below 0.5
 }
 
 export interface BridgeProvider {
@@ -14,13 +15,58 @@ export interface BridgeProvider {
   status(id: string): Promise<string>;
 }
 
-// TODO(devin): implement adapters. Start with CCTP + Mayan + HFSP (3 is enough to prove aggregation).
-export const PROVIDERS: Partial<Record<string, BridgeProvider>> = {
-  cctp:      undefined, // Circle CCTP — native 1:1 USDC, lowest cost, no slippage. DEFAULT BENCHMARK.
-  mayan:     undefined, // Mayan Finance — Solana-native (Wormhole + Swift/MCTP)
-  hfsp:      undefined, // our x402 relayer (generalize gnosis-card-x402); carries integrator fee natively
-  debridge:  undefined, // deBridge DLN — fast intent-based
-  wormhole:  undefined, // Portal token bridge — canonical fallback
-  allbridge: undefined, // Allbridge — stablecoin Solana<->EVM
-  lifi:      undefined, // LI.FI — meta-aggregator; useful as a sanity benchmark
+// Solana mainnet chain id used by deBridge etc.
+export const SOLANA_DLN_CHAIN_ID = 7565164;
+
+// 1. Circle CCTP — native 1:1 USDC, no slippage. DEFAULT BENCHMARK.
+const cctp: BridgeProvider = {
+  name: "cctp",
+  supports: (_chain, token) => token.toLowerCase() === "usdc",
+  async quote() { throw new Error("TODO(devin): CCTP — depositForBurn + Iris attestation; out ~= in - gas. See PROVIDERS.md #1"); },
+  async execute() { throw new Error("TODO(devin): CCTP execute"); },
+  async status() { throw new Error("TODO(devin): CCTP status via Iris messageHash"); },
 };
+
+// 2. Mayan Finance — Solana-native (Swift/MCTP/Wormhole). price-api.mayan.finance/v3/quote
+const mayan: BridgeProvider = {
+  name: "mayan",
+  supports: () => true,
+  async quote() { throw new Error("TODO(devin): Mayan v3 quote API; pick best route. See PROVIDERS.md #2"); },
+  async execute() { throw new Error("TODO(devin): Mayan swapFromSolana via SDK"); },
+  async status() { throw new Error("TODO(devin): Mayan tracking API"); },
+};
+
+// 3. deBridge DLN — fast intent-based. dln.debridge.finance/v1.0/dln/order/quote
+const debridge: BridgeProvider = {
+  name: "debridge",
+  supports: () => true,
+  async quote() { throw new Error("TODO(devin): deBridge DLN quote (srcChainId=7565164). See PROVIDERS.md #3"); },
+  async execute() { throw new Error("TODO(devin): deBridge create-tx + sign on Solana"); },
+  async status() { throw new Error("TODO(devin): deBridge order status"); },
+};
+
+// 4. Wormhole / Portal — canonical fallback; prefer CCTP route via Connect. @wormhole-foundation/sdk
+const wormhole: BridgeProvider = {
+  name: "wormhole",
+  supports: () => true,
+  async quote() { throw new Error("TODO(devin): Wormhole SDK route quote; higher eta for VAA. See PROVIDERS.md #4"); },
+  async execute() { throw new Error("TODO(devin): Wormhole transfer + VAA + redeem"); },
+  async status() { throw new Error("TODO(devin): Wormhole VAA/redeem status"); },
+};
+
+// 5. Allbridge Core — stablecoin pools. @allbridge/bridge-core-sdk
+const allbridge: BridgeProvider = {
+  name: "allbridge",
+  supports: (_chain, token) => token.toLowerCase() === "usdc",
+  async quote() { throw new Error("TODO(devin): Allbridge getAmountToBeReceived. See PROVIDERS.md #5"); },
+  async execute() { throw new Error("TODO(devin): Allbridge send + sign on Solana"); },
+  async status() { throw new Error("TODO(devin): Allbridge status by tx"); },
+};
+
+// Aggregator pool — exactly 5 external bridge providers.
+export const PROVIDERS: Record<string, BridgeProvider> = {
+  cctp, mayan, debridge, wormhole, allbridge,
+};
+
+// Optional 6th: HFSP x402 relayer (generalized gnosis-card-x402) — execution/fee layer,
+// register here only if you also want it quoted as a route. It carries the integrator fee natively.

--- a/prep-kits/solana-x402-bridge/scripts/providers.ts
+++ b/prep-kits/solana-x402-bridge/scripts/providers.ts
@@ -1,5 +1,6 @@
-// Bridge provider adapters — 5 Solana -> EVM providers ranked by the aggregator.
-// Spec for each: see PROVIDERS.md. Add a provider = add one adapter implementing BridgeProvider.
+// Bridge/swap provider adapters — 5 Solana -> EVM providers. Spec: PROVIDERS.md.
+// Same-asset bridge (USDC->USDC) AND cross-chain swap (SOL->ETH) supported where the
+// provider allows. Eligibility is decided per-pair by supportsPair().
 import type { BridgeQuote, BridgeResult, EvmChain } from "./types.js";
 
 export interface ProviderQuote extends BridgeQuote {
@@ -9,64 +10,64 @@ export interface ProviderQuote extends BridgeQuote {
 
 export interface BridgeProvider {
   name: string;
-  supports(chain: EvmChain, token: string): boolean;
-  quote(amountUSDC: number, chain: EvmChain, token: string): Promise<ProviderQuote>;
-  execute(amountUSDC: number, chain: EvmChain, token: string): Promise<BridgeResult>;
+  // supportsPair: can this provider move srcToken on Solana to destToken on destChain?
+  supportsPair(srcToken: string, chain: EvmChain, destToken: string): boolean;
+  quote(srcToken: string, amountIn: number, chain: EvmChain, destToken: string): Promise<ProviderQuote>;
+  execute(srcToken: string, amountIn: number, chain: EvmChain, destToken: string): Promise<BridgeResult>;
   status(id: string): Promise<string>;
 }
 
-// Solana mainnet chain id used by deBridge etc.
 export const SOLANA_DLN_CHAIN_ID = 7565164;
+const isStable = (t: string) => ["usdc", "usdt"].includes(t.toLowerCase());
+const sameAsset = (a: string, b: string) => a.toLowerCase() === b.toLowerCase();
 
-// 1. Circle CCTP — native 1:1 USDC, no slippage. DEFAULT BENCHMARK.
+// 1. Circle CCTP — USDC->USDC only, native 1:1, no slippage. DEFAULT BENCHMARK.
 const cctp: BridgeProvider = {
   name: "cctp",
-  supports: (_chain, token) => token.toLowerCase() === "usdc",
-  async quote() { throw new Error("TODO(devin): CCTP — depositForBurn + Iris attestation; out ~= in - gas. See PROVIDERS.md #1"); },
+  supportsPair: (s, _c, d) => s.toLowerCase() === "usdc" && d.toLowerCase() === "usdc",
+  async quote() { throw new Error("TODO(devin): CCTP burn/mint; impact=0. PROVIDERS.md #1"); },
   async execute() { throw new Error("TODO(devin): CCTP execute"); },
-  async status() { throw new Error("TODO(devin): CCTP status via Iris messageHash"); },
+  async status() { throw new Error("TODO(devin): CCTP Iris status"); },
 };
 
-// 2. Mayan Finance — Solana-native (Swift/MCTP/Wormhole). price-api.mayan.finance/v3/quote
+// 2. Mayan — ANY token -> ANY token (cross-chain swap). Best for SOL->ETH. price-api.mayan.finance/v3/quote
 const mayan: BridgeProvider = {
   name: "mayan",
-  supports: () => true,
-  async quote() { throw new Error("TODO(devin): Mayan v3 quote API; pick best route. See PROVIDERS.md #2"); },
-  async execute() { throw new Error("TODO(devin): Mayan swapFromSolana via SDK"); },
-  async status() { throw new Error("TODO(devin): Mayan tracking API"); },
+  supportsPair: () => true, // any->any
+  async quote() { throw new Error("TODO(devin): Mayan v3 quote (any->any); include priceImpact + minOut. PROVIDERS.md #2"); },
+  async execute() { throw new Error("TODO(devin): Mayan swapFromSolana"); },
+  async status() { throw new Error("TODO(devin): Mayan tracking"); },
 };
 
-// 3. deBridge DLN — fast intent-based. dln.debridge.finance/v1.0/dln/order/quote
+// 3. deBridge DLN — ANY token -> ANY token (intent market). Supports SOL->ETH.
 const debridge: BridgeProvider = {
   name: "debridge",
-  supports: () => true,
-  async quote() { throw new Error("TODO(devin): deBridge DLN quote (srcChainId=7565164). See PROVIDERS.md #3"); },
-  async execute() { throw new Error("TODO(devin): deBridge create-tx + sign on Solana"); },
+  supportsPair: () => true, // any->any
+  async quote() { throw new Error("TODO(devin): deBridge DLN quote (srcChainId=7565164); include impact. PROVIDERS.md #3"); },
+  async execute() { throw new Error("TODO(devin): deBridge create-tx + sign"); },
   async status() { throw new Error("TODO(devin): deBridge order status"); },
 };
 
-// 4. Wormhole / Portal — canonical fallback; prefer CCTP route via Connect. @wormhole-foundation/sdk
+// 4. Wormhole/Portal — same-asset bridge + CCTP route. SOL->ETH only via added swap legs (treat as limited).
 const wormhole: BridgeProvider = {
   name: "wormhole",
-  supports: () => true,
-  async quote() { throw new Error("TODO(devin): Wormhole SDK route quote; higher eta for VAA. See PROVIDERS.md #4"); },
+  supportsPair: (s, _c, d) => sameAsset(s, d) || (s.toLowerCase() === "usdc" && d.toLowerCase() === "usdc"),
+  async quote() { throw new Error("TODO(devin): Wormhole SDK route; higher eta for VAA. PROVIDERS.md #4"); },
   async execute() { throw new Error("TODO(devin): Wormhole transfer + VAA + redeem"); },
-  async status() { throw new Error("TODO(devin): Wormhole VAA/redeem status"); },
+  async status() { throw new Error("TODO(devin): Wormhole VAA status"); },
 };
 
-// 5. Allbridge Core — stablecoin pools. @allbridge/bridge-core-sdk
+// 5. Allbridge Core — stablecoin pools only (USDC/USDT). No SOL->ETH.
 const allbridge: BridgeProvider = {
   name: "allbridge",
-  supports: (_chain, token) => token.toLowerCase() === "usdc",
-  async quote() { throw new Error("TODO(devin): Allbridge getAmountToBeReceived. See PROVIDERS.md #5"); },
-  async execute() { throw new Error("TODO(devin): Allbridge send + sign on Solana"); },
-  async status() { throw new Error("TODO(devin): Allbridge status by tx"); },
+  supportsPair: (s, _c, d) => isStable(s) && isStable(d),
+  async quote() { throw new Error("TODO(devin): Allbridge getAmountToBeReceived. PROVIDERS.md #5"); },
+  async execute() { throw new Error("TODO(devin): Allbridge send + sign"); },
+  async status() { throw new Error("TODO(devin): Allbridge status"); },
 };
 
-// Aggregator pool — exactly 5 external bridge providers.
+// Aggregator pool — exactly 5 external providers.
+// SOL->ETH eligible set resolves to: mayan, debridge (cctp/allbridge/wormhole filtered out).
 export const PROVIDERS: Record<string, BridgeProvider> = {
   cctp, mayan, debridge, wormhole, allbridge,
 };
-
-// Optional 6th: HFSP x402 relayer (generalized gnosis-card-x402) — execution/fee layer,
-// register here only if you also want it quoted as a route. It carries the integrator fee natively.

--- a/prep-kits/solana-x402-bridge/scripts/providers.ts
+++ b/prep-kits/solana-x402-bridge/scripts/providers.ts
@@ -1,0 +1,26 @@
+// Bridge provider adapters. Add a provider = add one object implementing BridgeProvider.
+import type { BridgeQuote, BridgeResult, EvmChain } from "./types.js";
+
+export interface ProviderQuote extends BridgeQuote {
+  provider: string;
+  reliabilityScore: number; // 0..1, used by aggregator filter
+}
+
+export interface BridgeProvider {
+  name: string;
+  supports(chain: EvmChain, token: string): boolean;
+  quote(amountUSDC: number, chain: EvmChain, token: string): Promise<ProviderQuote>;
+  execute(amountUSDC: number, chain: EvmChain, token: string): Promise<BridgeResult>;
+  status(id: string): Promise<string>;
+}
+
+// TODO(devin): implement adapters. Start with CCTP + Mayan + HFSP (3 is enough to prove aggregation).
+export const PROVIDERS: Partial<Record<string, BridgeProvider>> = {
+  cctp:      undefined, // Circle CCTP — native 1:1 USDC, lowest cost, no slippage. DEFAULT BENCHMARK.
+  mayan:     undefined, // Mayan Finance — Solana-native (Wormhole + Swift/MCTP)
+  hfsp:      undefined, // our x402 relayer (generalize gnosis-card-x402); carries integrator fee natively
+  debridge:  undefined, // deBridge DLN — fast intent-based
+  wormhole:  undefined, // Portal token bridge — canonical fallback
+  allbridge: undefined, // Allbridge — stablecoin Solana<->EVM
+  lifi:      undefined, // LI.FI — meta-aggregator; useful as a sanity benchmark
+};

--- a/prep-kits/solana-x402-bridge/scripts/rpc-health.ts
+++ b/prep-kits/solana-x402-bridge/scripts/rpc-health.ts
@@ -1,0 +1,15 @@
+// RPC freshness + failover. Reject stale endpoints; never act on lagging state.
+import { Connection } from "@solana/web3.js";
+
+export async function getHealthyConnection() {
+  const primary = process.env.SOLANA_RPC_URL!;
+  const fallbacks = (process.env.SOLANA_FALLBACK_RPCS ?? "").split(",").map((s) => s.trim()).filter(Boolean);
+  const endpoints = [primary, ...fallbacks];
+
+  // TODO(devin): query getSlot across endpoints, compute lag vs max observed slot,
+  // pick lowest-lag healthy endpoint; throw if none under RPC_MAX_SLOT_LAG.
+  const endpoint = endpoints[0];
+  const connection = new Connection(endpoint, "confirmed");
+  const slotLag = 0; // TODO: real measurement
+  return { connection, slotLag, endpoint };
+}

--- a/prep-kits/solana-x402-bridge/scripts/rpc-health.ts
+++ b/prep-kits/solana-x402-bridge/scripts/rpc-health.ts
@@ -1,15 +1,84 @@
-// RPC freshness + failover. Reject stale endpoints; never act on lagging state.
+// Cross-chain RPC health switcher. Detects lagging/failing endpoints and fails over
+// BEFORE execution — on both the Solana source and the EVM destination.
+// Never act on a stale/unhealthy RPC.
 import { Connection } from "@solana/web3.js";
 
-export async function getHealthyConnection() {
-  const primary = process.env.SOLANA_RPC_URL!;
-  const fallbacks = (process.env.SOLANA_FALLBACK_RPCS ?? "").split(",").map((s) => s.trim()).filter(Boolean);
-  const endpoints = [primary, ...fallbacks];
+const TIMEOUT_MS = Number(process.env.RPC_PROBE_TIMEOUT_MS ?? 2500);
 
-  // TODO(devin): query getSlot across endpoints, compute lag vs max observed slot,
-  // pick lowest-lag healthy endpoint; throw if none under RPC_MAX_SLOT_LAG.
-  const endpoint = endpoints[0];
-  const connection = new Connection(endpoint, "confirmed");
-  const slotLag = 0; // TODO: real measurement
-  return { connection, slotLag, endpoint };
+async function withTimeout<T>(p: Promise<T>): Promise<T> {
+  return Promise.race([
+    p,
+    new Promise<T>((_, rej) => setTimeout(() => rej(new Error("rpc timeout")), TIMEOUT_MS)),
+  ]);
 }
+
+// ---------- Solana ----------
+export async function getHealthySolana() {
+  const endpoints = [process.env.SOLANA_RPC_URL!, ...split(process.env.SOLANA_FALLBACK_RPCS)];
+  const maxLag = Number(process.env.RPC_MAX_SLOT_LAG ?? 150);
+
+  const probes = await Promise.all(endpoints.map(async (url) => {
+    const t0 = Date.now();
+    try {
+      const slot = await withTimeout(new Connection(url, "confirmed").getSlot());
+      return { url, slot, latency: Date.now() - t0, ok: true as const };
+    } catch { return { url, slot: -1, latency: Infinity, ok: false as const }; }
+  }));
+
+  const healthy = probes.filter((p) => p.ok);
+  if (!healthy.length) throw new Error("No healthy Solana RPC endpoint");
+  const maxSlot = Math.max(...healthy.map((p) => p.slot));
+  const eligible = healthy
+    .map((p) => ({ ...p, lag: maxSlot - p.slot }))
+    .filter((p) => p.lag <= maxLag)
+    .sort((a, b) => a.lag - b.lag || a.latency - b.latency);
+
+  if (!eligible.length) throw new Error(`All Solana RPCs stale (> ${maxLag} slots behind)`);
+  const best = eligible[0];
+  return { connection: new Connection(best.url, "confirmed"), slotLag: best.lag, endpoint: best.url };
+}
+
+// Back-compat alias used by bridge-safety.
+export const getHealthyConnection = getHealthySolana;
+
+// ---------- EVM ----------
+// Per-chain fallback RPCs via env, e.g. POLYGON_FALLBACK_RPCS, ETHEREUM_FALLBACK_RPCS.
+export async function getHealthyEvmRpc(chain: string) {
+  const primary = process.env[`${chain.toUpperCase()}_RPC_URL`];
+  const fallbacks = split(process.env[`${chain.toUpperCase()}_FALLBACK_RPCS`]);
+  const endpoints = [primary, ...fallbacks].filter(Boolean) as string[];
+  if (!endpoints.length) throw new Error(`No RPC configured for ${chain}`);
+
+  const probes = await Promise.all(endpoints.map(async (url) => {
+    const t0 = Date.now();
+    try {
+      const block = await withTimeout(evmBlockNumber(url));
+      return { url, block, latency: Date.now() - t0, ok: true as const };
+    } catch { return { url, block: -1, latency: Infinity, ok: false as const }; }
+  }));
+
+  const healthy = probes.filter((p) => p.ok);
+  if (!healthy.length) throw new Error(`No healthy ${chain} RPC endpoint`);
+  const maxBlock = Math.max(...healthy.map((p) => p.block));
+  const maxLag = Number(process.env.EVM_MAX_BLOCK_LAG ?? 10);
+  const eligible = healthy
+    .map((p) => ({ ...p, lag: maxBlock - p.block }))
+    .filter((p) => p.lag <= maxLag)
+    .sort((a, b) => a.lag - b.lag || a.latency - b.latency);
+
+  if (!eligible.length) throw new Error(`All ${chain} RPCs stale (> ${maxLag} blocks behind)`);
+  const best = eligible[0];
+  return { endpoint: best.url, blockLag: best.lag, latency: best.latency };
+}
+
+async function evmBlockNumber(url: string): Promise<number> {
+  const res = await fetch(url, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "eth_blockNumber", params: [] }),
+  });
+  const json = await res.json();
+  return parseInt(json.result, 16);
+}
+
+function split(v?: string) { return (v ?? "").split(",").map((s) => s.trim()).filter(Boolean); }

--- a/prep-kits/solana-x402-bridge/scripts/types.ts
+++ b/prep-kits/solana-x402-bridge/scripts/types.ts
@@ -1,15 +1,27 @@
-// Shared contracts for the solana-x402-bridge skill.
-// Devin: implement against these interfaces. Keep the skill client thin — no secrets here.
+// Shared contracts for solana-x402-bridge. Generalized to ANY token (bridge or cross-chain swap).
+// Devin: implement against these. Keep the skill client thin — no secrets here.
 
-export type EvmChain = "polygon" | "gnosis" | "base" | "arbitrum";
+export type EvmChain = "polygon" | "gnosis" | "base" | "arbitrum" | "ethereum";
+
+// A bridge is a same-asset transfer (USDC->USDC). A swap is cross-chain with a different
+// destination token (SOL->ETH) and carries slippage/price impact.
+export type TransferKind = "bridge" | "swap";
 
 export interface BridgeQuote {
+  kind: TransferKind;
   route: string;
-  amountInUSDC: number;
+  srcChain: "solana";
+  srcToken: string;        // e.g. "USDC", "SOL"
+  destChain: EvmChain;
+  destToken: string;       // e.g. "USDC", "ETH"
+  amountIn: number;        // in srcToken units
+  amountOut: number;       // in destToken units (net of all fees + swap impact)
   bridgeFeeUSDC: number;
   bridgeFeeBps: number;
   networkFeesUSDC: number;
-  amountOutUSDC: number;
+  priceImpactBps: number;  // 0 for same-asset bridges; >0 for swaps
+  minAmountOut: number;    // amountOut after applying slippage tolerance
+  slippageBps: number;
   etaSeconds: number;
   feeRecipient: string;
   relayer: string;
@@ -17,7 +29,7 @@ export interface BridgeQuote {
 
 export interface SafetyResult {
   ok: boolean;
-  failures: string[];      // human-readable reasons; empty when ok
+  failures: string[];
   rpcSlotLag: number;
   usedRpc: string;
 }

--- a/prep-kits/solana-x402-bridge/scripts/types.ts
+++ b/prep-kits/solana-x402-bridge/scripts/types.ts
@@ -1,0 +1,31 @@
+// Shared contracts for the solana-x402-bridge skill.
+// Devin: implement against these interfaces. Keep the skill client thin — no secrets here.
+
+export type EvmChain = "polygon" | "gnosis" | "base" | "arbitrum";
+
+export interface BridgeQuote {
+  route: string;
+  amountInUSDC: number;
+  bridgeFeeUSDC: number;
+  bridgeFeeBps: number;
+  networkFeesUSDC: number;
+  amountOutUSDC: number;
+  etaSeconds: number;
+  feeRecipient: string;
+  relayer: string;
+}
+
+export interface SafetyResult {
+  ok: boolean;
+  failures: string[];      // human-readable reasons; empty when ok
+  rpcSlotLag: number;
+  usedRpc: string;
+}
+
+export interface BridgeResult {
+  sourceTx: string;
+  destTx: string;
+  statusId: string;
+  sourceExplorer: string;
+  destExplorer: string;
+}

--- a/prep-kits/solana-x402-bridge/skills/bridge-aggregator/SKILL.md
+++ b/prep-kits/solana-x402-bridge/skills/bridge-aggregator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bridge-aggregator
-description: Aggregate multiple cross-chain bridge providers (Circle CCTP, Mayan, deBridge, Wormhole, Allbridge, LI.FI, HFSP x402) and return the best route for a Solana to EVM USDC transfer, ranked by amount-out net of all fees and gas. The "Jupiter of cross-chain". Use for "best bridge rate", "cheapest way to bridge", "compare bridges", "aggregate bridge quote".
+description: Aggregate multiple cross-chain bridge providers (Circle CCTP, Mayan, deBridge, Wormhole, Allbridge, LI.FI, HFSP x402) and return the best route for a Solana to EVM transfer — same-asset bridge (USDC->USDC) or cross-chain swap (e.g. SOL->ETH), ranked by amount-out net of all fees and gas. The "Jupiter of cross-chain". Use for "best bridge rate", "cheapest way to bridge", "compare bridges", "aggregate bridge quote".
 ---
 
 # bridge-aggregator

--- a/prep-kits/solana-x402-bridge/skills/bridge-aggregator/SKILL.md
+++ b/prep-kits/solana-x402-bridge/skills/bridge-aggregator/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: bridge-aggregator
+description: Aggregate multiple cross-chain bridge providers (Circle CCTP, Mayan, deBridge, Wormhole, Allbridge, LI.FI, HFSP x402) and return the best route for a Solana to EVM USDC transfer, ranked by amount-out net of all fees and gas. The "Jupiter of cross-chain". Use for "best bridge rate", "cheapest way to bridge", "compare bridges", "aggregate bridge quote".
+---
+
+# bridge-aggregator
+
+Quote every supported provider in parallel; return the best net route + the full comparison.
+
+## How it ranks
+1. Query all `BridgeProvider` adapters (`scripts/providers.ts`) for (amount, destChain, destToken).
+2. Normalize each quote to `amountOutUSDC` after provider fee + gas.
+3. Filter: drop providers above `maxEtaSeconds` or below the reliability floor.
+4. Add the transparent HFSP integrator fee on top (INTEGRATOR_FEE_BPS).
+5. Rank by net amountOut; tie-break on speed. Return winner + ranked list.
+
+## Rules
+- USDC default benchmark = **Circle CCTP** (native 1:1, no slippage) — always include it.
+- ALWAYS return the per-provider comparison, not just the winner — proving best-rate selection is the product.
+- Adding a provider = one new adapter file implementing the `BridgeProvider` interface.
+
+Run `scripts/bridge-quote.ts` (aggregates) — it calls the aggregator internally.

--- a/prep-kits/solana-x402-bridge/skills/bridge-execute/SKILL.md
+++ b/prep-kits/solana-x402-bridge/skills/bridge-execute/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: bridge-execute
+description: Execute a USDC bridge from Solana to an EVM chain via the x402 relayer, after a quote and safety preflight. Returns source and destination transaction hashes and a status handle. Use for "do the bridge", "send the USDC", "execute bridge to Polygon".
+---
+
+# bridge-execute
+
+Performs the bridge. Only after `bridge-quote` AND a passing `bridge-safety` preflight.
+
+## Flow
+1. Re-confirm quote is fresh.
+2. Pay the relayer via x402 (USDC on Solana) — payment header carries the source tx.
+3. Relayer settles native USDC on the destination chain (~45–90s).
+4. Return `{ sourceTx, destTx, statusId }` with explorer links.
+
+## Rules
+- Never execute without a passing safety preflight (allowlist, caps, freshness).
+- Poll `/status/:id` on the relayer until settled; surface both chain confirmations.
+- Reuse the proven flow in `packages/gnosis-card-x402`.
+- Run `scripts/bridge-execute.ts`.

--- a/prep-kits/solana-x402-bridge/skills/bridge-quote/SKILL.md
+++ b/prep-kits/solana-x402-bridge/skills/bridge-quote/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: bridge-quote
+description: Quote a USDC bridge from Solana to an EVM chain. Returns route, transparent fee breakdown, network fees, amount out, and ETA. Always call before bridge-execute. Use for "how much to bridge", "bridge quote", "cost to send USDC to Polygon/EVM".
+---
+
+# bridge-quote
+
+Read-only. Quote a Solana→EVM USDC bridge via the x402 relayer.
+
+## Input
+`amountUSDC`, `destChain` (see evm-targets), `destToken` (default USDC).
+
+## Output (always disclose the fee)
+```json
+{
+  "route": "USDC Solana → Polygon (x402)",
+  "amountIn": "5.00 USDC",
+  "bridgeFee": "0.0075 USDC (15 bps)",
+  "networkFees": "~0.01 USDC",
+  "amountOut": "4.98 USDC",
+  "etaSeconds": 45,
+  "feeRecipient": "<integratorFeeAccount or HFSP default>",
+  "relayer": "https://bridge.clawdrop.live"
+}
+```
+
+## Rules
+- Fee = relayer x402 price. Configurable via INTEGRATOR_FEE_BPS / INTEGRATOR_FEE_ACCOUNT.
+- Never hide or round away the fee — it is a feature, show it in full.
+- Run `scripts/bridge-quote.ts`.

--- a/prep-kits/solana-x402-bridge/skills/bridge-safety/SKILL.md
+++ b/prep-kits/solana-x402-bridge/skills/bridge-safety/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: bridge-safety
+description: Mandatory preflight before any bridge execution. Enforces destination allowlist, per-transaction and daily spend caps, slippage / minimum amount-out, and a stale-RPC freshness guard that refuses to act on lagging chain state. Use whenever a bridge or cross-chain transfer is about to execute.
+---
+
+# bridge-safety
+
+The guard that makes moving funds safe. ALWAYS run before `bridge-execute`.
+
+## Checks (fail loud — never silently proceed)
+1. **Destination allowlist** — destChain ∈ DEST_ALLOWLIST.
+2. **Spend caps** — amount ≤ MAX_BRIDGE_USDC_PER_TX and rolling 24h ≤ MAX_BRIDGE_USDC_PER_DAY.
+3. **Slippage / min-out** — amountOut ≥ user minimum.
+4. **Freshness guard** — source RPC slot-lag ≤ RPC_MAX_SLOT_LAG; otherwise fail over (scripts/rpc-health.ts) or abort. A lagging RPC = stale balance = do NOT bridge.
+5. **Confirmation monitor** — after execute, confirm on both source and dest chains.
+
+## Why the freshness guard matters
+Bridging on a stale balance read can double-spend or strand funds. Treat a stale slot as "do not act."
+
+Run `scripts/bridge-safety.ts` (uses `scripts/rpc-health.ts`).

--- a/prep-kits/solana-x402-bridge/skills/bridge-safety/SKILL.md
+++ b/prep-kits/solana-x402-bridge/skills/bridge-safety/SKILL.md
@@ -18,3 +18,9 @@ The guard that makes moving funds safe. ALWAYS run before `bridge-execute`.
 Bridging on a stale balance read can double-spend or strand funds. Treat a stale slot as "do not act."
 
 Run `scripts/bridge-safety.ts` (uses `scripts/rpc-health.ts`).
+
+## Swap slippage (any-token transfers, e.g. SOL->ETH)
+For `kind: "swap"` quotes (different destToken), additionally:
+- Reject if `amountOut < minAmountOut` (slippage tolerance, DEFAULT_SLIPPAGE_BPS).
+- Re-quote right before execute; abort if price drifted beyond tolerance.
+Same-asset bridges (USDC->USDC) have priceImpactBps=0 and skip this.

--- a/prep-kits/solana-x402-bridge/skills/bridge-safety/SKILL.md
+++ b/prep-kits/solana-x402-bridge/skills/bridge-safety/SKILL.md
@@ -24,3 +24,9 @@ For `kind: "swap"` quotes (different destToken), additionally:
 - Reject if `amountOut < minAmountOut` (slippage tolerance, DEFAULT_SLIPPAGE_BPS).
 - Re-quote right before execute; abort if price drifted beyond tolerance.
 Same-asset bridges (USDC->USDC) have priceImpactBps=0 and skip this.
+
+## RPC health switcher (both chains)
+Backed by `scripts/rpc-health.ts`:
+- **Solana source:** probes `getSlot` across SOLANA_RPC_URL + SOLANA_FALLBACK_RPCS, picks lowest slot-lag healthy endpoint, fails if all > RPC_MAX_SLOT_LAG behind.
+- **EVM destination:** probes `eth_blockNumber` across <CHAIN>_RPC_URL + <CHAIN>_FALLBACK_RPCS, picks freshest/lowest-latency, fails if all > EVM_MAX_BLOCK_LAG behind.
+A failing/lagging RPC on either side blocks execution — agents on a single RPC are fragile; this auto-swaps endpoints before acting.

--- a/prep-kits/solana-x402-bridge/skills/evm-targets/SKILL.md
+++ b/prep-kits/solana-x402-bridge/skills/evm-targets/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: evm-targets
+description: Registry of EVM chains, token addresses, and relayer endpoints supported by the bridge. Use to discover which destination chains and tokens are available and their identifiers. Use for "which chains are supported", "list EVM targets", "Polygon USDC address".
+---
+
+# evm-targets
+
+Source of truth for supported destinations.
+
+## Each entry
+`{ chain, chainId, relayerEndpoint, tokens: { USDC: <address>, ... }, finalitySeconds }`
+
+## MVP coverage
+- polygon (Polymarket lives here — mandatory)
+- gnosis (already live via gnosis-card-x402)
+- base
+- arbitrum (stretch)
+
+Keep addresses canonical (USDC.e vs native USDC on Polygon — be explicit; Polymarket uses USDC.e).
+
+Run `scripts/evm-targets.ts` to print the registry.

--- a/prep-kits/solana-x402-bridge/skills/fiat-onramp/SKILL.md
+++ b/prep-kits/solana-x402-bridge/skills/fiat-onramp/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: fiat-onramp
+description: Fund a Solana agent with fiat (card/bank) or cash out to fiat, via Onramper — an aggregator of 20+ on/off-ramp providers across 130+ payment methods. Returns the best ranked onramp/offramp quote, disclosed transparently. Use for "fund with fiat", "buy USDC with card", "onramp", "cash out to bank", "offramp winnings".
+---
+
+# fiat-onramp
+
+Onramper integration — the fiat aggregator that mirrors our bridge aggregator.
+
+## Onramp (fiat -> crypto)
+- Quote fiat -> USDC delivered on Solana OR directly on the destination EVM chain.
+- Onramper ranks 20+ providers; surface its best quote next to the bridge quote so the agent picks "fund + bridge" vs "fund directly on destination".
+
+## Offramp (crypto -> fiat)
+- Quote USDC -> fiat for cashing out (e.g. Polymarket winnings).
+
+## Rules
+- Quote-first, fee always disclosed (same rule as bridges).
+- API key via env (`ONRAMPER_API_KEY`); requests signed. Widget or pure API.
+- Supports onramp, offramp, and crypto swaps via one unified API.
+
+Run `scripts/onramp.ts quote|offramp ...`.

--- a/prep-kits/solana-x402-bridge/skills/polymarket-bet/SKILL.md
+++ b/prep-kits/solana-x402-bridge/skills/polymarket-bet/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: polymarket-bet
+description: Place and redeem bets on Polymarket using USDC.e on Polygon. Requires USDC on Polygon first (bridge via bridge-execute). Use for "bet on Polymarket", "buy YES/NO shares", "redeem my winnings". Demo flagship of the cross-chain skill.
+---
+
+# polymarket-bet
+
+Place / redeem Polymarket bets. Polygon USDC.e required — bridge first via `bridge-execute`.
+
+## Flow
+1. Ensure USDC.e balance on Polygon (else trigger bridge-quote → safety → execute).
+2. Place order via CLOB (market or limit), specify outcome (YES/NO) + size.
+3. Return order id + resulting position.
+4. Redeem after resolution.
+
+## Rules
+- Confirm market is open and not near-resolution before betting.
+- Respect spend caps from bridge-safety config.
+- Demo with small amounts.
+
+Run `scripts/polymarket.ts bet <marketId> <YES|NO> <amount>`.

--- a/prep-kits/solana-x402-bridge/skills/polymarket-read/SKILL.md
+++ b/prep-kits/solana-x402-bridge/skills/polymarket-read/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: polymarket-read
+description: Read Polymarket prediction markets — search/list markets, current YES/NO odds, liquidity, resolution status, and the user's open positions. Demo layer on top of the bridge (Polymarket runs on Polygon). Use for "show Polymarket markets", "odds on <event>", "my Polymarket positions".
+---
+
+# polymarket-read
+
+Read-only access to Polymarket (Polygon) via the CLOB API.
+
+## Capabilities
+- search/list active markets (by keyword/category)
+- current odds (YES/NO price), liquidity, volume, end date
+- resolution status
+- user positions for a given EVM address
+
+No bridge needed for reads. Run `scripts/polymarket.ts read ...`.


### PR DESCRIPTION
## What this is
A **prep kit / scaffold** for our Superteam Brasil bounty submission: a Solana AI Kit skill that gives Solana agents **cross-chain execution** — bridge USDC to any EVM chain via our x402 relayer (generalized from `packages/gnosis-card-x402`), with **Polymarket betting** as the flagship demo.

Devin: start from [`prep-kits/solana-x402-bridge/BUILD-BRIEF.md`](prep-kits/solana-x402-bridge/BUILD-BRIEF.md) — it's the complete spec.

## Why this idea
- ~158 bounty submissions; **no real cross-chain bridge skill exists** (the one named `solana-bridge-skill` is mislabeled frontend codegen).
- **No Polymarket / betting skill exists** anywhere.
- We already built the core bridge (`gnosis-card-x402`). This generalizes it to any-EVM + adds the betting demo.
- Genuine white space + already-built core + cross-chain "wow" demo.

## Contents
- `BUILD-BRIEF.md` — architecture, modules, **fee model** (relayer-side x402, 5–25 bps, configurable, disclosed), acceptance criteria, 24h build order.
- `SKILL.md` router + 6 module `SKILL.md`s: bridge-quote / bridge-execute / bridge-safety / evm-targets / polymarket-read / polymarket-bet.
- `scripts/` typed contracts (`types.ts`) + stubs with TODOs.
- `examples/demo/cross-chain-bet.md` — the 60s demo.
- MIT `LICENSE`, `package.json`, `.env.example`.

## Build order (24h)
1. `evm-targets` + `bridge-quote` (read-only)
2. `bridge-safety` + `rpc-health` (guardrails)
3. `bridge-execute` (wire to generalized relayer)
4. Generalize `gnosis-card-x402` relayer to multi-EVM + fee param
5. `polymarket-read` → `polymarket-bet` (flagship)
6. README + demo recording

Stop after step 3 = valid winning bridge submission. 4–6 make it spectacular.

🤖 Generated with [Claude Code](https://claude.com/claude-code)