### PR TITLE
Prep kit: solana-scheduled-payments skill (Multihopper, separate)

### DIFF
--- a/prep-kits/solana-scheduled-payments/.env.example
+++ b/prep-kits/solana-scheduled-payments/.env.example
@@ -1,0 +1,4 @@
+# Multihopper
+MULTIHOPPER_API_KEY=        # mh_live_... or mh_test_...
+SOLANA_RPC_URL=
+SOLANA_WALLET_PRIVATE_KEY=  # signs locally; never sent to the API

--- a/prep-kits/solana-scheduled-payments/BUILD-BRIEF.md
+++ b/prep-kits/solana-scheduled-payments/BUILD-BRIEF.md
@@ -1,0 +1,36 @@
+# BUILD BRIEF — `solana-scheduled-payments` (Multihopper-backed)
+
+**Separate skill** from solana-x402-bridge. Do not merge the two.
+**Goal:** A Solana AI Kit skill that lets an agent create programmable, scheduled, multi-hop SPL token transfers (vesting, payroll, escrow, treasury) via the Multihopper protocol — with client-side signing so keys never leave the agent.
+
+## Why it's a candidate
+- Distinct white space: scheduled/recurring on-chain payment pipelines are not covered by the kit's existing skills or the bounty field (escrow has only 1 weak competitor, scheduled-payroll has none).
+- Backed by a real protocol (Multihopper) — already-built infra, agent/MCP-ready.
+- Strong safety posture: API manages create/prepare/confirm; **signing stays local, private keys never reach the server.**
+
+## What Multihopper provides (the backend)
+- Solana-native protocol for scheduled, multi-hop token transfers using on-chain timelocks + a permissionless keeper network.
+- Any SPL token (`tokenMint`). Solana only (NOT cross-chain — that's why it's separate from the bridge).
+- Lifecycle: **create → prepare → sign locally → broadcast (ordered) → confirm → poll**.
+- Auth: `x-api-key` (`mh_live_...` / `mh_test_...`).
+- Mainnet compliance: sanctions/risk screening by keeper; flat ~0.002 SOL screening deposit at prepare time (refunded for clean routes).
+- Docs: https://dev-docs.multihopper.com/  (agentic: /guides/agentic-integration, MCP: /mcp)
+
+## Modules (4)
+1. **create-pipeline** — define recipients, amounts, timing, and sequence; returns a transferId.
+2. **prepare-and-sign** — fetch unsigned base64 txs, sign locally (keys never leave client), broadcast in mandatory order (keeper funding → route/orchestrator/session), confirm signatures back to the API.
+3. **pipeline-status** — poll completion; handle blockhash expiry (~60s) by re-preparing with a new idempotency key.
+4. **compliance-screening** — surface the screening deposit/flow; report flagged routes.
+
+## Use cases to demo
+Vesting unlock schedule, payroll batch, milestone escrow release, treasury drip.
+
+## Build order (this is a SECONDARY submission — only after the bridge ships)
+1. create-pipeline (REST create) + pipeline-status (poll).
+2. prepare-and-sign (the careful part — ordered broadcast, v0 vs legacy signing, never overwrite server pre-signatures).
+3. compliance-screening.
+
+## Notes
+- Reuse Multihopper's TS examples (@solana/web3.js) for signing/broadcast.
+- Keep `sign_and_broadcast` local; everything else is an HTTP wrapper.
+- This skill is independent: own repo, own bounty PR.

--- a/prep-kits/solana-scheduled-payments/LICENSE
+++ b/prep-kits/solana-scheduled-payments/LICENSE
@@ -1,0 +1,1 @@
+MIT License — Copyright (c) 2026 HFSP Labs / Clawdrop

--- a/prep-kits/solana-scheduled-payments/README.md
+++ b/prep-kits/solana-scheduled-payments/README.md
@@ -1,0 +1,19 @@
+# solana-scheduled-payments
+
+**Programmable, scheduled token payments for Solana agents.** Create multi-hop transfer pipelines — vesting, payroll, escrow, treasury drips — that execute on-chain over time, with client-side signing so keys never leave the agent. Backed by the Multihopper protocol.
+
+> Separate skill from `solana-x402-bridge`. Solana-native; not cross-chain.
+
+## Modules
+| Module | Purpose |
+|---|---|
+| `create-pipeline` | Define recipients, amounts, timing, sequence → transferId |
+| `prepare-and-sign` | Fetch unsigned txs, sign locally, broadcast in order, confirm |
+| `pipeline-status` | Poll completion; handle blockhash expiry / resume |
+| `compliance-screening` | Sanctions/risk screening deposit + flagged-route reporting |
+
+## Status
+Prep kit / scaffold. See `BUILD-BRIEF.md`. Backend: https://dev-docs.multihopper.com/ — secondary submission, build after the bridge.
+
+## License
+MIT

--- a/prep-kits/solana-scheduled-payments/SKILL.md
+++ b/prep-kits/solana-scheduled-payments/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: solana-scheduled-payments
+description: Create and manage scheduled, multi-hop SPL token transfer pipelines on Solana — vesting, payroll, escrow, treasury drips — via the Multihopper protocol, with client-side signing (keys never leave the agent). Use for "schedule a payment", "vesting schedule", "payroll", "milestone escrow", "recurring transfer", "treasury drip".
+---
+
+# solana-scheduled-payments
+
+Router for Multihopper-backed scheduled payments. Solana-only (for cross-chain use `solana-x402-bridge`).
+
+1. **Define a schedule?** → `skills/create-pipeline`.
+2. **Sign + broadcast?** → `skills/prepare-and-sign` — keys stay local; broadcast in mandatory order.
+3. **Check progress?** → `skills/pipeline-status` — poll; re-prepare on blockhash expiry.
+4. **Mainnet compliance?** → `skills/compliance-screening`.
+
+## Golden rules
+- Signing is always local — never send private keys to the API.
+- Broadcast groups in order; each must confirm before the next.
+- On mainnet, account for the screening deposit (~0.002 SOL, refundable for clean routes).

--- a/prep-kits/solana-scheduled-payments/package.json
+++ b/prep-kits/solana-scheduled-payments/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "solana-scheduled-payments-skill",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Scheduled multi-hop SPL token payments for Solana agents (Multihopper-backed) — vesting, payroll, escrow, treasury.",
+  "type": "module",
+  "license": "MIT",
+  "scripts": {
+    "create": "tsx scripts/create-pipeline.ts",
+    "sign": "tsx scripts/prepare-and-sign.ts",
+    "status": "tsx scripts/pipeline-status.ts"
+  },
+  "dependencies": { "@solana/web3.js": "^1.95.0" },
+  "devDependencies": { "tsx": "^4.19.0", "typescript": "^5.6.0" }
+}

--- a/prep-kits/solana-scheduled-payments/scripts/create-pipeline.ts
+++ b/prep-kits/solana-scheduled-payments/scripts/create-pipeline.ts
@@ -1,0 +1,4 @@
+// usage: tsx scripts/create-pipeline.ts (define pipeline in code/args)
+// TODO(devin): POST pipeline def to Multihopper /create (x-api-key); return transferId.
+// Docs: https://dev-docs.multihopper.com/guides/agentic-integration
+throw new Error("TODO: implement Multihopper create-pipeline");

--- a/prep-kits/solana-scheduled-payments/scripts/pipeline-status.ts
+++ b/prep-kits/solana-scheduled-payments/scripts/pipeline-status.ts
@@ -1,0 +1,3 @@
+// usage: tsx scripts/pipeline-status.ts <transferId>
+// TODO(devin): poll status; on blockhash expiry re-/prepare with new idempotency key.
+throw new Error("TODO: implement Multihopper status poll");

--- a/prep-kits/solana-scheduled-payments/scripts/prepare-and-sign.ts
+++ b/prep-kits/solana-scheduled-payments/scripts/prepare-and-sign.ts
@@ -1,0 +1,4 @@
+// TODO(devin): /prepare -> sign locally (v0 add-signature / legacy partial) ->
+// broadcast ordered (keeper funding -> route/orchestrator/session) -> confirm twice.
+// Keys never leave the client. Reuse Multihopper @solana/web3.js examples.
+throw new Error("TODO: implement Multihopper prepare-and-sign");

--- a/prep-kits/solana-scheduled-payments/skills/compliance-screening/SKILL.md
+++ b/prep-kits/solana-scheduled-payments/skills/compliance-screening/SKILL.md
@@ -1,0 +1,6 @@
+---
+name: compliance-screening
+description: Handle Multihopper mainnet sanctions/risk screening for scheduled transfers — the refundable screening deposit and flagged-route reporting. Use for "compliance check", "is this route screened", "screening fee".
+---
+# compliance-screening
+On mainnet, the keeper screens routes post-deployment. A flat ~0.002 SOL deposit is taken at prepare time — refunded for clean routes, forfeited for flagged wallets. Surface status + reason to the user. Run `scripts/pipeline-status.ts` (screening fields).

--- a/prep-kits/solana-scheduled-payments/skills/create-pipeline/SKILL.md
+++ b/prep-kits/solana-scheduled-payments/skills/create-pipeline/SKILL.md
@@ -1,0 +1,6 @@
+---
+name: create-pipeline
+description: Define a scheduled multi-hop SPL token transfer on Solana — recipients, amounts, timing, and sequence — and create it via the Multihopper API, returning a transferId. Use for "schedule payments", "set up vesting/payroll", "create a payment pipeline".
+---
+# create-pipeline
+POST the pipeline definition (tokenMint, recipients, amounts, timing/sequence) to Multihopper; receive a transferId. Then proceed to prepare-and-sign. Auth via x-api-key. Run `scripts/create-pipeline.ts`.

--- a/prep-kits/solana-scheduled-payments/skills/pipeline-status/SKILL.md
+++ b/prep-kits/solana-scheduled-payments/skills/pipeline-status/SKILL.md
@@ -1,0 +1,6 @@
+---
+name: pipeline-status
+description: Poll a Multihopper transfer pipeline for completion status and handle blockhash expiry by re-preparing with a new idempotency key. Use for "check my scheduled payment", "is the vesting done", "transfer status".
+---
+# pipeline-status
+Poll completion. Solana blockhashes expire ~60s after prepare — on failure call `/prepare` again with a new idempotency key; already-confirmed groups return null (graceful resume). Run `scripts/pipeline-status.ts`.

--- a/prep-kits/solana-scheduled-payments/skills/prepare-and-sign/SKILL.md
+++ b/prep-kits/solana-scheduled-payments/skills/prepare-and-sign/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: prepare-and-sign
+description: Fetch unsigned Multihopper transactions, sign them locally (private keys never leave the client), and broadcast in the mandatory order, confirming signatures back to the API. Use after create-pipeline. Handles v0 versioned and legacy transactions.
+---
+# prepare-and-sign
+1. `/prepare` → unsigned base64 txs in groups.
+2. Sign locally — for v0, ADD your signature to existing slots (do NOT overwrite server pre-signatures); legacy uses partial sign.
+3. Broadcast in order: keeper funding first, then route/orchestrator/session.
+4. Confirm signatures to the API twice (after keeper funding, then after the rest).
+Keys never leave the client. Run `scripts/prepare-and-sign.ts`.


### PR DESCRIPTION
## What this is
A **separate, secondary** prep kit — independent from `solana-x402-bridge` (PR #10). A Solana AI Kit skill for scheduled, multi-hop SPL token pipelines (vesting, payroll, escrow, treasury) backed by the [Multihopper](https://dev-docs.multihopper.com/) protocol, with **client-side signing — private keys never leave the agent.**

## Why separate
Multihopper is Solana-only (no cross-chain/swaps), so it does not belong in the bridge kit. It fills different white space (scheduled payments / escrow — only 1 weak competitor in the bounty field).

## Contents
- `BUILD-BRIEF.md` — Multihopper lifecycle (create → prepare → sign locally → broadcast ordered → confirm → poll), modules, build order.
- `SKILL.md` router + 4 modules: create-pipeline, prepare-and-sign, pipeline-status, compliance-screening.
- Script stubs, README, MIT, env.

## Priority
**Secondary.** Build only after `solana-x402-bridge` ships. Own repo, own bounty PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)